### PR TITLE
Add derived (copy of: ...) label for duplicated campaignsFeature/copy of label

### DIFF
--- a/src/app/admin/(protected)/campaigns/[id]/page.tsx
+++ b/src/app/admin/(protected)/campaigns/[id]/page.tsx
@@ -42,6 +42,7 @@ import { EmailPreview } from "@/components/newsletter/EmailPreview";
 import { LinkBuilder } from "@/components/newsletter/LinkBuilder";
 import { ImageManager } from "@/components/newsletter/ImageManager";
 import { AudienceSelector } from "@/components/newsletter/AudienceSelector";
+import { CopyOfLabel } from "@/components/newsletter/CopyOfLabel";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import dynamic from "next/dynamic";
@@ -535,6 +536,7 @@ export default function CampaignDetailPage() {
                 />
               )}
             </div>
+            <CopyOfLabel copiedFrom={campaign.copiedFromCampaignId} />
           </div>
 
           {/* Action bar */}

--- a/src/app/admin/(protected)/campaigns/page.tsx
+++ b/src/app/admin/(protected)/campaigns/page.tsx
@@ -27,6 +27,7 @@ import { PaginationController } from "@/components/common";
 import { LinkBuilder } from "@/components/newsletter/LinkBuilder";
 import { ImageManager } from "@/components/newsletter/ImageManager";
 import { AudienceSelector } from "@/components/newsletter/AudienceSelector";
+import { CopyOfLabel } from "@/components/newsletter/CopyOfLabel";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
@@ -446,9 +447,12 @@ export default function AdminPage() {
                 >
                   {/* Simple Mono Title */}
                   <div className="flex items-center gap-2 p-2 border-b border-border/25 bg-secondary/10">
-                    <h3 className="text-lg font-mono font-bold tracking-[0.2em] uppercase text-foreground group-hover:text-primary transition-colors truncate flex-1">
-                      {c.title}
-                    </h3>
+                    <div className="flex-1 min-w-0 truncate">
+                      <h3 className="text-lg font-mono font-bold tracking-[0.2em] uppercase text-foreground group-hover:text-primary transition-colors truncate">
+                        {c.title}
+                      </h3>
+                      <CopyOfLabel copiedFrom={c.copiedFromCampaignId} />
+                    </div>
                     <div className="flex items-center gap-2">
                       <span className="text-[8px] font-mono tracking-widest uppercase border border-primary/30 px-1.5 py-0.5 rounded-lg text-primary/70">
                         {TYPE_LABELS[c.campaignType] || c.campaignType}

--- a/src/components/newsletter/CopyOfLabel.tsx
+++ b/src/components/newsletter/CopyOfLabel.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useCampaign, ICampaign } from "@/hooks";
+import { cn } from "@/lib/utils";
+
+interface CopyOfLabelProps {
+  copiedFrom: ICampaign["copiedFromCampaignId"];
+  className?: string;
+}
+
+/**
+ * Renders a small, visually subordinate "(copy of: <title>)" label for
+ * campaigns duplicated from another campaign.
+ *
+ * `copiedFromCampaignId` may come back from the API as either:
+ *  - a populated object: { _id, title }
+ *  - a raw ObjectId string, in which case we fetch the referenced
+ *    campaign to resolve its title.
+ */
+export function CopyOfLabel({ copiedFrom, className }: CopyOfLabelProps) {
+  const isPopulated = !!copiedFrom && typeof copiedFrom === "object";
+  const idToResolve = !isPopulated && copiedFrom ? copiedFrom : "";
+
+  // useCampaign is a no-op (enabled: false) when passed an empty id.
+  const { data: resolvedCampaign } = useCampaign(idToResolve);
+
+  if (!copiedFrom) return null;
+
+  const originalTitle = isPopulated ? copiedFrom.title : resolvedCampaign?.title;
+
+  if (!originalTitle) return null;
+
+  return (
+    <span
+      className={cn(
+        "text-[10px] font-mono text-muted-foreground/60 tracking-widest uppercase truncate",
+        className,
+      )}
+    >
+      (copy of: {originalTitle})
+    </span>
+  );
+}

--- a/src/hooks/marketing/use-campaigns.ts
+++ b/src/hooks/marketing/use-campaigns.ts
@@ -109,6 +109,9 @@ export interface ICampaign {
   };
   dispatchTotal?: number;
   dispatchedAt?: string;
+  // May come back as a raw ObjectId string, or populated with a title
+  // if the backend expands the reference. Both are handled by CopyOfLabel.
+  copiedFromCampaignId?: string | { _id: string; title: string } | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
Adds a derived "(copy of: ...)" label to campaigns that were duplicated,
read from `copiedFromCampaignId`, instead of mutating the title with "(COPY)".

## Changes
- `ICampaign.copiedFromCampaignId` type added (handles raw id or populated `{_id, title}`)
- New `CopyOfLabel` component resolves and renders the label
- Wired into campaign list view (under title) and detail view (under subject line)

## Acceptance criteria
- [x] Duplicated campaign shows original title in "(copy of: ...)" label
- [x] Campaign title is not mutated with "(COPY)"
- [x] Label is visually subordinate (smaller, muted, no border-radius)
- [x] Uses existing oklch design tokens