### PR TITLE
Fix mobile nav active route tracking and relabel Rooms to Quizzes

### DIFF
--- a/src/components/app/layout/app-sidebar.tsx
+++ b/src/components/app/layout/app-sidebar.tsx
@@ -84,10 +84,6 @@ export function AppSidebar() {
 
   const currentPose = QUBI_POSES[poseIndex];
 
-  const handleNextPose = () => {
-    setPoseIndex((prev) => (prev + 1) % QUBI_POSES.length);
-  };
-
   const handleNewSession = async () => {
     try {
       const session = await createSession.mutateAsync({ mode: "structured" });
@@ -141,11 +137,11 @@ export function AppSidebar() {
     <aside className="hidden border-r border-slate-200 bg-white lg:flex lg:h-screen lg:w-[248px] lg:flex-col lg:sticky lg:top-0 shrink-0">
       {/* Brand & Animated Qubi Mascot Header */}
       <div className="flex h-18 items-center border-b border-slate-100 px-3 py-2 bg-gradient-to-br from-blue-50/60 via-white to-indigo-50/30 relative overflow-hidden shrink-0">
-        {/* Interactive Rotating Qubi Header Card */}
-        <div
-          onClick={handleNextPose}
+        {/* Qubi Mascot — links to the app's home route (/app) */}
+        <Link
+          href="/app"
+          aria-label="Qz home"
           className="group cursor-pointer w-full h-full flex items-center gap-2.5 rounded-2xl border border-slate-200/90 bg-white px-3 py-1.5 shadow-2xs hover:border-[#0C60FC]/40 transition"
-          title="Click to cycle Qubi postures"
         >
           <div className="relative h-12 w-12 shrink-0 overflow-hidden rounded-xl bg-[#F7F9FC] flex items-center justify-center">
             <AnimatePresence mode="wait">
@@ -180,7 +176,7 @@ export function AppSidebar() {
               </motion.div>
             </AnimatePresence>
           </div>
-        </div>
+        </Link>
       </div>
 
       {/* Main Navigation Scroll Area */}

--- a/src/components/landing/MobileNav.tsx
+++ b/src/components/landing/MobileNav.tsx
@@ -1,25 +1,54 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+interface NavItem {
+  href: string;
+  icon: string;
+  label: string;
+  // True when the link is "exact match" (e.g. /); false for prefix match.
+  exact?: boolean;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { href: "/", icon: "⌂", label: "Home", exact: true },
+  { href: "/quizzes", icon: "▦", label: "Quizzes" },
+  { href: "/library", icon: "☐", label: "Library" },
+  { href: "/timetable", icon: "▤", label: "Timetable" },
+];
 
 export function MobileNav() {
+  const pathname = usePathname();
+
   return (
     <nav
       className="frosted fixed inset-x-3 bottom-3 z-50 grid grid-cols-4 rounded-2xl border border-slate-200 p-1.5 shadow-2xl md:hidden"
       aria-label="Mobile navigation"
     >
-      <Link href="/" className="flex flex-col items-center rounded-xl bg-blue-50 py-2 text-[9px] font-bold text-[#0C60FC]">
-        <span className="text-base">⌂</span>Home
-      </Link>
-      <Link href="/study-rooms" className="flex flex-col items-center py-2 text-[9px] font-bold text-slate-500 hover:text-slate-900">
-        <span className="text-base">◍</span>Rooms
-      </Link>
-      <Link href="/library" className="flex flex-col items-center py-2 text-[9px] font-bold text-slate-500 hover:text-slate-900">
-        <span className="text-base">▦</span>Library
-      </Link>
-      <Link href="/timetable" className="flex flex-col items-center py-2 text-[9px] font-bold text-slate-500 hover:text-slate-900">
-        <span className="text-base">▤</span>Timetable
-      </Link>
+      {NAV_ITEMS.map((item) => {
+        const isActive = item.exact
+          ? pathname === item.href
+          : pathname === item.href || pathname.startsWith(`${item.href}/`);
+
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            aria-current={isActive ? "page" : undefined}
+            className={cn(
+              "flex flex-col items-center rounded-xl py-2 text-[9px] font-bold transition-colors",
+              isActive
+                ? "bg-blue-50 text-[#0C60FC]"
+                : "text-slate-500 hover:text-slate-900",
+            )}
+          >
+            <span className="text-base">{item.icon}</span>
+            {item.label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }


### PR DESCRIPTION
This pull request updates navigation components to improve usability and maintainability. The main changes include refactoring the mobile navigation to use a data-driven approach with active state highlighting, and simplifying the sidebar header interaction.

Navigation improvements:

* Refactored `MobileNav` to define navigation items in a `NAV_ITEMS` array and render them dynamically, making it easier to add or update navigation links. Active links are now highlighted based on the current route using `usePathname`, improving the user experience.
* Updated navigation icons and labels for consistency and clarity in the mobile navigation.

Sidebar header simplification:

* Changed the Qubi mascot in the sidebar header from a clickable element that cycled poses to a static link to the app’s home route (`/app`), simplifying the interaction and removing the unused `handleNextPose` function. [[1]](diffhunk://#diff-a29c84d85e48a6d0b7e6b0a98cc92847a880f2e29d876c5af790b45e6c1e737dL87-L90) [[2]](diffhunk://#diff-a29c84d85e48a6d0b7e6b0a98cc92847a880f2e29d876c5af790b45e6c1e737dL144-L148) [[3]](diffhunk://#diff-a29c84d85e48a6d0b7e6b0a98cc92847a880f2e29d876c5af790b45e6c1e737dL183-R179)