### PR TITLE
Fix usage counters not updating within 5s of a tracked action

### DIFF
--- a/src/hooks/app/use-app-actions.ts
+++ b/src/hooks/app/use-app-actions.ts
@@ -37,6 +37,13 @@ export const useCreateApp = () => {
       };
     },
     onSuccess: () => {
+      // Starting a session consumes the tutorSessions daily usage counter
+      // server-side (enforceUsageLimit runs before the session is created),
+      // so the Usage page's counter needs to refresh here too, not just the
+      // session list.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.billing.status(),
+      });
       return queryClient.invalidateQueries({
         queryKey: queryKeys.app.lists(),
       });

--- a/src/hooks/app/use-app-library.ts
+++ b/src/hooks/app/use-app-library.ts
@@ -187,6 +187,12 @@ export const useCreateLibraryMaterial = () => {
       return res.data.data;
     },
     onSuccess: () => {
+      // Uploading consumes the materialUploads daily usage counter
+      // server-side before the material is created, so refresh billing
+      // status alongside the material list.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.billing.status(),
+      });
       queryClient.invalidateQueries({
         queryKey: queryKeys.library.materials.root(),
       });
@@ -233,6 +239,11 @@ export const useGenerateFlashcards = () => {
       return res.data;
     },
     onSuccess: () => {
+      // flashcardSets is consumed server-side before generation kicks off,
+      // so the counter is already updated by the time this resolves.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.billing.status(),
+      });
       queryClient.invalidateQueries({
         queryKey: queryKeys.library.flashcards.root(),
       });
@@ -256,6 +267,11 @@ export const useGenerateQuiz = () => {
       return res.data;
     },
     onSuccess: () => {
+      // quizGenerations is consumed server-side before generation kicks off,
+      // so the counter is already updated by the time this resolves.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.billing.status(),
+      });
       queryClient.invalidateQueries({
         queryKey: queryKeys.library.quizzes.root(),
       });
@@ -330,6 +346,11 @@ export const useGenerateMindMap = () => {
       return res.data;
     },
     onSuccess: () => {
+      // mindMaps is consumed server-side before generation kicks off, so
+      // the counter is already updated by the time this resolves.
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.billing.status(),
+      });
       queryClient.invalidateQueries({
         queryKey: queryKeys.library.mindmaps.root(),
       });


### PR DESCRIPTION
## Root cause
All five daily usage limits (tutor sessions, quiz/flashcard/mind-map generation, material uploads) are consumed server-side via `enforceUsageLimit`/`consumeUsageOnSuccess` *before* each request's initial response — so the counter is already correct by the time the mutation resolves. But `queryKeys.billing.status()` (which the Usage page reads via `useBillingStatus`, 30s staleTime) was never invalidated by any mutation — grepped the whole `src/hooks` tree and it's only referenced in its own definition. So the Usage page kept showing stale counts until the 30s staleTime lapsed or the window refocused, not within 5s of the action like the issue requires.

## Fix
Added `queryClient.invalidateQueries({ queryKey: queryKeys.billing.status() })` to the `onSuccess` of the five mutations that actually consume a daily-limit feature, matched 1:1 against the backend's `enforceUsageLimit(...)` call sites:
- `useCreateApp` (`src/hooks/app/use-app-actions.ts`) → tutorSessions
- `useCreateLibraryMaterial` → materialUploads
- `useGenerateFlashcards` → flashcardSets
- `useGenerateQuiz` → quizGenerations
- `useGenerateMindMap` → mindMaps

(all four generate/create mutations in `src/hooks/app/use-app-library.ts`)

## Test plan
- [x] `npx tsc --noEmit` clean (ESLint itself is currently broken in this repo — `eslint@10.7.0` incompatible with `eslint-config-next`'s bundled `eslint-plugin-react`, pre-existing and unrelated to this change, not something I touched)
- [x] Verified live end-to-end with a throwaway test account (created and deleted afterward):
  - Started a new Z session → `POST /app` 201 → navigated to `/app/usage` (client-side nav, not a hard reload) → counter correctly showed 1/2, and a fresh `billing-status` network request fired on that navigation rather than serving the 30s-stale cache
  - Attempted a second session while already at the free-tier daily limit → correctly got `402` from the backend, and the Usage page continued showing the accurate 1/2 (not double-counted)
- [x] No test data left behind

Closes #74