### PR TITLE
[update]: reate reusable credit bundle component and update responsive pages

### DIFF
--- a/src/app/(app)/app/billing/page.tsx
+++ b/src/app/(app)/app/billing/page.tsx
@@ -12,7 +12,7 @@ import {
   type PlanDuration,
   type BillingPackage,
 } from "@/hooks";
-import { ReferralCard } from "@/components/common";
+import { ReferralCard, CreditBundleCard } from "@/components/common";
 import { cn } from "@/lib/utils";
 
 const PLAN_TIER_META: Record<
@@ -191,36 +191,6 @@ function buildMissing(pkg: BillingPackage): string[] {
   return m;
 }
 
-// ─── Credit bundle card ────────────────────────────────────────────────────────
-
-function CreditBundleCard({
-  bundle,
-  onSelect,
-}: {
-  bundle: { _id: string; name: string; priceGHS: number; credits: number };
-  onSelect: (id: string) => void;
-}) {
-  return (
-    <article className="rounded-2xl border border-slate-200 bg-white p-6 text-center shadow-sm flex flex-col justify-between">
-      <div>
-        <span className="flex h-10 w-10 mx-auto items-center justify-center rounded-xl bg-blue-50 text-blue-700">
-          <Zap className="h-5 w-5" strokeWidth={2.25} />
-        </span>
-        <h3 className="mt-3 text-base font-extrabold text-slate-950">{bundle.name}</h3>
-        <p className="mt-2 text-2xl font-extrabold text-slate-950">GHS {bundle.priceGHS}</p>
-        <p className="mt-1 text-xs text-slate-500">{bundle.credits} extra generation credits</p>
-      </div>
-      <button
-        type="button"
-        onClick={() => onSelect(bundle._id)}
-        className="mt-5 w-full rounded-xl bg-slate-950 py-2.5 text-xs font-extrabold text-white hover:bg-[#0C60FC] transition"
-      >
-        Buy {bundle.credits} credits
-      </button>
-    </article>
-  );
-}
-
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function BillingPage() {
@@ -271,10 +241,14 @@ export default function BillingPage() {
             {billingStatus?.planTier ? (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 px-3 py-1.5 text-emerald-700 ring-1 ring-emerald-200">
                 <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
-                On {PLAN_TIER_META[billingStatus.planTier]?.label ?? billingStatus.planTier}
+                On{" "}
+                {PLAN_TIER_META[billingStatus.planTier]?.label ??
+                  billingStatus.planTier}
               </span>
             ) : (
-              <span className="rounded-full bg-slate-100 px-3 py-1.5">Free tier</span>
+              <span className="rounded-full bg-slate-100 px-3 py-1.5">
+                Free tier
+              </span>
             )}
             {billingStatus?.credits?.balance !== undefined && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1.5 text-amber-700 ring-1 ring-amber-200">
@@ -307,7 +281,9 @@ export default function BillingPage() {
                 <span
                   className={cn(
                     "rounded-full px-2 py-0.5 text-[9px] font-extrabold",
-                    duration === d ? "bg-[#DFFF61] text-slate-900" : "bg-[#DFFF61] text-slate-900",
+                    duration === d
+                      ? "bg-[#DFFF61] text-slate-900"
+                      : "bg-[#DFFF61] text-slate-900",
                   )}
                 >
                   Best value
@@ -330,9 +306,12 @@ export default function BillingPage() {
             </div>
           ) : sorted.length === 0 ? (
             <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white py-20">
-              <p className="text-sm font-bold text-slate-700">No plans available</p>
+              <p className="text-sm font-bold text-slate-700">
+                No plans available
+              </p>
               <p className="mt-1 max-w-sm text-center text-xs font-semibold text-slate-500">
-                We couldn&apos;t find any plans for this cycle. Try a different cycle or check back later.
+                We couldn&apos;t find any plans for this cycle. Try a different
+                cycle or check back later.
               </p>
             </div>
           ) : (
@@ -363,7 +342,8 @@ export default function BillingPage() {
 
           {/* Free-tier note */}
           <p className="mx-auto mt-6 max-w-3xl rounded-2xl bg-[#F7F9FC] px-5 py-4 text-center text-xs font-semibold text-slate-500">
-            Free tier — always available. 1 Z session / day, 2 quizzes / day, 2 flashcard sets / day, 1 mind map / day. No card required.
+            Free tier — always available. 1 Z session / day, 2 quizzes / day, 2
+            flashcard sets / day, 1 mind map / day. No card required.
           </p>
         </div>
       </section>
@@ -373,12 +353,15 @@ export default function BillingPage() {
         <section className="bg-[#F7F9FC] px-6 py-12 lg:px-8">
           <div className="mx-auto max-w-7xl">
             <div className="text-center">
-              <p className="hand text-2xl text-[#0C60FC]">need extra generations? ✦</p>
+              <p className="hand text-2xl text-[#0C60FC]">
+                need extra generations? ✦
+              </p>
               <h2 className="mt-1 text-2xl font-bold text-slate-950 sm:text-3xl">
                 Pay-as-you-go Credits
               </h2>
               <p className="mt-2 text-sm text-slate-600">
-                Credits never expire. Top up anytime for extra quizzes and flashcards.
+                Credits never expire. Top up anytime for extra quizzes and
+                flashcards.
               </p>
             </div>
 
@@ -390,11 +373,13 @@ export default function BillingPage() {
                 </p>
               </div>
             ) : (
-              <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                {creditBundles.map((bundle) => (
+              <div className="mt-12 flex flex-wrap justify-center gap-5">
+                {creditBundles.map((bundle, idx) => (
                   <CreditBundleCard
                     key={bundle._id}
                     bundle={bundle}
+                    index={idx}
+                    totalCount={creditBundles.length}
                     onSelect={handleSelectBundle}
                   />
                 ))}
@@ -410,7 +395,9 @@ export default function BillingPage() {
         <div className="pointer-events-none absolute -right-32 bottom-10 h-80 w-80 rounded-full bg-[#DFFF61]/10 blur-3xl" />
         <div className="relative mx-auto max-w-7xl">
           <div className="text-center">
-            <p className="hand text-3xl text-[#DFFF61]">consistency literally pays ✦</p>
+            <p className="hand text-3xl text-[#DFFF61]">
+              consistency literally pays ✦
+            </p>
             <h2 className="mt-1 text-2xl font-bold tracking-tight sm:text-3xl">
               Discounts &amp; rewards
             </h2>
@@ -423,42 +410,56 @@ export default function BillingPage() {
             <article className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
               <p className="text-3xl font-extrabold text-[#DFFF61]">10% off</p>
               <p className="mt-3 text-sm font-bold text-white">Student</p>
-              <p className="mt-1 text-xs text-slate-400">Verify your university email</p>
+              <p className="mt-1 text-xs text-slate-400">
+                Verify your university email
+              </p>
             </article>
             <article className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
               <p className="text-3xl font-extrabold text-[#DFFF61]">15% off</p>
               <p className="mt-3 text-sm font-bold text-white">Referral</p>
-              <p className="mt-1 text-xs text-slate-400">Earn when a friend subscribes</p>
+              <p className="mt-1 text-xs text-slate-400">
+                Earn when a friend subscribes
+              </p>
             </article>
             <article className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
               <p className="text-3xl font-extrabold text-[#DFFF61]">10% off</p>
               <p className="mt-3 text-sm font-bold text-white">7-day streak</p>
-              <p className="mt-1 text-xs text-slate-400">Keep your streak going</p>
+              <p className="mt-1 text-xs text-slate-400">
+                Keep your streak going
+              </p>
             </article>
             <article className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
               <p className="text-3xl font-extrabold text-[#DFFF61]">20% off</p>
               <p className="mt-3 text-sm font-bold text-white">30-day streak</p>
-              <p className="mt-1 text-xs text-slate-400">On your next renewal</p>
+              <p className="mt-1 text-xs text-slate-400">
+                On your next renewal
+              </p>
             </article>
             <article className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur-sm">
               <p className="text-3xl font-extrabold text-[#DFFF61]">30% off</p>
               <p className="mt-3 text-sm font-bold text-white">60-day streak</p>
-              <p className="mt-1 text-xs text-slate-400">Or a free week — loyalty milestone</p>
+              <p className="mt-1 text-xs text-slate-400">
+                Or a free week — loyalty milestone
+              </p>
             </article>
             <article className="rounded-2xl bg-[#0C60FC] p-6 shadow-2xl shadow-blue-500/30">
               <p className="text-3xl font-extrabold text-white">15% forever</p>
               <p className="mt-3 text-sm font-bold text-white">90-day streak</p>
-              <p className="mt-1 text-xs text-blue-100">Lifetime loyalty discount</p>
+              <p className="mt-1 text-xs text-blue-100">
+                Lifetime loyalty discount
+              </p>
             </article>
           </div>
 
           {isVerifiedStudent ? (
             <p className="mx-auto mt-10 max-w-3xl text-center text-xs font-semibold text-emerald-300">
-              ✦ Student discount active — your 10% discount is applied automatically at checkout.
+              ✦ Student discount active — your 10% discount is applied
+              automatically at checkout.
             </p>
           ) : (
             <p className="mx-auto mt-10 max-w-3xl text-center text-xs font-semibold text-slate-400">
-              Student discount — verify your university email in settings after signing up.
+              Student discount — verify your university email in settings after
+              signing up.
             </p>
           )}
         </div>

--- a/src/app/(app)/app/courses/page.tsx
+++ b/src/app/(app)/app/courses/page.tsx
@@ -27,12 +27,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-const SEMESTERS = ["Semester 1", "Semester 2", "Summer Session"];
-const ACADEMIC_YEARS = ["2024-2025", "2025-2026", "2026-2027"];
+const SEMESTERS = ["Semester 1", "Semester 2"];
+const ACADEMIC_YEARS = ["2025-2026", "2026-2027"];
 
 export default function MyCoursesPage() {
   const [selectedSemester, setSelectedSemester] = useState("Semester 1");
-  const [selectedYear, setSelectedYear] = useState("2025-2026");
+  const [selectedYear, setSelectedYear] = useState("2026-2027");
 
   const { data: enrollments = [], isLoading: isEnrollmentsLoading } =
     useMyCourses();
@@ -137,21 +137,25 @@ export default function MyCoursesPage() {
               <span className="text-[10px] font-extrabold uppercase tracking-widest text-slate-400 w-20 shrink-0">
                 Year
               </span>
-              {ACADEMIC_YEARS.map((y) => (
-                <button
-                  key={y}
-                  type="button"
-                  onClick={() => setSelectedYear(y)}
-                  className={cn(
-                    "rounded-full px-4 py-2 text-xs font-bold transition",
-                    selectedYear === y
-                      ? "bg-slate-950 text-white"
-                      : "bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50",
-                  )}
-                >
-                  {y}
-                </button>
-              ))}
+              {ACADEMIC_YEARS.map((y) => {
+                const isPast = y === "2025-2026";
+                return (
+                  <button
+                    key={y}
+                    type="button"
+                    onClick={() => setSelectedYear(y)}
+                    className={cn(
+                      "rounded-full px-4 py-2 text-xs font-bold transition",
+                      isPast && "line-through",
+                      selectedYear === y
+                        ? "bg-slate-950 text-white"
+                        : "bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-50",
+                    )}
+                  >
+                    {y}
+                  </button>
+                );
+              })}
             </div>
           </div>
 
@@ -178,7 +182,7 @@ export default function MyCoursesPage() {
             </div>
           ) : enrollments.length > 0 ? (
             <motion.div
-              className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5"
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5"
               variants={{
                 hidden: {},
                 visible: { transition: { staggerChildren: 0.06 } },
@@ -212,12 +216,11 @@ export default function MyCoursesPage() {
               </AnimatePresence>
             </motion.div>
           ) : (
-            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white py-20">
+            <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-white px-6 py-20">
               <BookOpen className="mb-4 h-12 w-12 text-slate-300" />
               <p className="text-sm font-bold text-slate-700">No courses yet</p>
-              <p className="mt-1 max-w-sm text-center text-xs font-semibold text-slate-500">
-                Stay organized by tracking the courses you're taking this term —
-                we'll wire them into exam reminders and timetables for you.
+              <p className="mt-1 max-w-xs text-center text-xs font-semibold text-slate-500">
+                Add the courses you're taking this term.
               </p>
               <button
                 type="button"

--- a/src/app/(app)/app/quizzes/page.tsx
+++ b/src/app/(app)/app/quizzes/page.tsx
@@ -223,7 +223,7 @@ export default function QuizzesPage() {
             </div>
           ) : (
             <motion.div
-              className="grid gap-5 md:grid-cols-2 xl:grid-cols-3"
+              className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3"
               variants={{
                 hidden: {},
                 visible: { transition: { staggerChildren: 0.06 } },

--- a/src/app/(app)/app/timetable/page.tsx
+++ b/src/app/(app)/app/timetable/page.tsx
@@ -27,6 +27,7 @@ import {
   type IExamSessionEntry,
 } from "@/hooks/app/use-timetable";
 import { useMyCourses } from "@/hooks/app/use-user-courses";
+import { useIsMobile } from "@/hooks";
 import { useAuth } from "@/contexts/auth-context";
 import { toast } from "sonner";
 
@@ -78,9 +79,8 @@ const WEEK_DAYS = [
   { day: "WED", date: "14", isToday: false, dotColor: "bg-violet-400" },
   { day: "THU", date: "15", isToday: false, dotColor: "bg-amber-400" },
   { day: "FRI", date: "16", isToday: false, dotColor: "bg-emerald-400" },
-  { day: "MON", date: "19", isToday: false, dotColor: "bg-cyan-400" },
-  { day: "WED", date: "21", isToday: false, dotColor: "bg-rose-400" },
-  { day: "FRI", date: "23", isToday: false, dotColor: "bg-amber-400" },
+  { day: "SAT", date: "17", isToday: false, dotColor: "bg-cyan-400" },
+  { day: "SUN", date: "18", isToday: false, dotColor: "bg-rose-400" },
 ];
 
 // Events for the week grid. Each event has a day (1-5 = MON-FRI in the grid)
@@ -184,6 +184,7 @@ const WEEK_DAY_LABELS = ["MON", "TUE", "WED", "THU", "FRI"] as const;
 export default function PrivateTimetablePage() {
   const router = useRouter();
   const { user } = useAuth();
+  const isMobile = useIsMobile();
   const [activeTab, setActiveTab] = useState<TabView>("week");
   const [selectedSemester, setSelectedSemester] = useState("Semester 1");
   const [selectedYear, setSelectedYear] = useState("2025-2026");
@@ -350,8 +351,9 @@ export default function PrivateTimetablePage() {
                     id="tabs"
                     className="date-rail flex gap-1 overflow-x-auto rounded-xl bg-[#F0F3F8] p-1"
                   >
-                    {(["week", "month", "agenda", "exams"] as TabView[]).map(
-                      (tab) => (
+                    {(["week", "month", "agenda", "exams"] as TabView[])
+                      .filter((tab) => !(isMobile && tab === "month"))
+                      .map((tab) => (
                         <button
                           key={tab}
                           onClick={() => setActiveTab(tab)}
@@ -363,18 +365,17 @@ export default function PrivateTimetablePage() {
                         >
                           {tab}
                         </button>
-                      ),
-                    )}
+                      ))}
                   </div>
                 </div>
               </div>
 
               {/* Date Selector Rail */}
-              <div className="date-rail mt-5 flex gap-2 overflow-x-auto pb-1">
+              <div className="date-rail mt-5 grid grid-cols-7 gap-2 pb-1">
                 {WEEK_DAYS.map((d, idx) => (
                   <div
                     key={idx}
-                    className={`min-w-16 rounded-2xl p-3 text-center transition ${
+                    className={`min-w-0 rounded-2xl p-2 sm:p-3 text-center transition ${
                       d.isToday
                         ? "bg-[#0C60FC] text-white shadow-md"
                         : "bg-slate-50 text-slate-900"
@@ -480,8 +481,58 @@ export default function PrivateTimetablePage() {
                     </div>
                   </div>
 
-                  {/* Mobile-friendly list fallback (visible below `lg`) */}
-                  <div className="mt-5 space-y-3 lg:hidden">
+                  {/* Tablet Timetable Grid (md only) */}
+                  <div className="mt-5 hidden md:block lg:hidden">
+                    <div className="grid grid-cols-[44px_repeat(5,minmax(0,1fr))] gap-1 pb-2 text-center font-bold">
+                      <span />
+                      {WEEK_DAY_LABELS.map((label, idx) => {
+                        const isFirst = idx === 0;
+                        return (
+                          <span
+                            key={label}
+                            className={`rounded-none py-1 text-[10px] ${
+                              isFirst ? "bg-blue-50 text-[#0C60FC]" : "text-slate-500"
+                            }`}
+                          >
+                            {label} {WEEK_DAYS[idx]?.date}
+                          </span>
+                        );
+                      })}
+                    </div>
+
+                    <div className="grid grid-cols-[44px_repeat(5,minmax(0,1fr))] grid-rows-[repeat(10,36px)] gap-1">
+                      {TIME_SLOTS.map((t, i) => (
+                        <span
+                          key={t}
+                          className="text-[9px] font-extrabold uppercase text-slate-400"
+                          style={{ gridColumn: 1, gridRow: i + 1 }}
+                        >
+                          {t}
+                        </span>
+                      ))}
+
+                      {WEEK_EVENTS.map((event, i) => {
+                        const tone = EVENT_TONE_CLS[event.tone];
+                        return (
+                          <div
+                            key={i}
+                            className={`rounded-none px-1.5 py-1 ${tone.bg} ${tone.text} ${tone.ring ?? ""}`}
+                            style={{
+                              gridColumn: event.day + 1,
+                              gridRow: `${event.startRow} / ${event.endRow}`,
+                            }}
+                          >
+                            <b className="block truncate text-[10px] font-bold leading-tight">
+                              {event.title}
+                            </b>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Mobile-friendly list fallback (visible below `md`) */}
+                  <div className="mt-5 space-y-3 md:hidden">
                     {WEEK_EVENTS.length === 0 ? (
                       <p className="rounded-2xl border border-dashed border-slate-200 p-6 text-center text-xs font-semibold text-slate-400">
                         No classes scheduled this week.
@@ -522,7 +573,27 @@ export default function PrivateTimetablePage() {
             )}
 
             {/* TAB 2: MONTH VIEW */}
-            {activeTab === "month" && (
+            {activeTab === "month" && isMobile && (
+              <section className="panel rounded-none border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+                <div className="flex flex-col items-start gap-2">
+                  <h2 className="text-base font-bold text-slate-950">
+                    Month view isn't available on small screens
+                  </h2>
+                  <p className="text-xs font-semibold text-slate-500">
+                    Showing your week instead.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setActiveTab("week")}
+                    className="rounded-none border border-slate-200 bg-[#0C60FC] px-3 py-2 text-[10px] font-extrabold uppercase tracking-wider text-white"
+                  >
+                    Switch to week
+                  </button>
+                </div>
+              </section>
+            )}
+
+            {activeTab === "month" && !isMobile && (
               <section className="panel p-4 sm:p-5 rounded-[28px] border border-slate-200 bg-white shadow-sm">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div>
@@ -677,11 +748,11 @@ export default function PrivateTimetablePage() {
             {/* TAB 3: AGENDA VIEW */}
             {activeTab === "agenda" && (
               <section className="panel p-5 rounded-[28px] border border-slate-200 bg-white shadow-sm space-y-4">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-base font-bold text-slate-950">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <h2 className="min-w-0 text-base font-bold text-slate-950">
                     Upcoming Agenda
                   </h2>
-                  <div className="relative w-60">
+                  <div className="relative w-full sm:w-60">
                     <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
                     <input
                       type="text"
@@ -983,7 +1054,7 @@ export default function PrivateTimetablePage() {
 
               {/* Weekly Workload Visual Bar Chart */}
               <div className="space-y-2 pt-1">
-                <p className="text-[10px] font-extrabold uppercase tracking-wider text-slate-400">
+                <p className="text-[11px] font-extrabold uppercase tracking-wider text-slate-400 sm:text-xs">
                   Daily Study Hours
                 </p>
                 <div className="grid grid-cols-5 gap-2 items-end h-28 pt-4 pb-1 border-b border-slate-100">
@@ -995,14 +1066,14 @@ export default function PrivateTimetablePage() {
                     { day: "Fri", hrs: 2.5, pct: "40%", color: "bg-blue-300" },
                   ].map((bar) => (
                     <div key={bar.day} className="flex flex-col items-center gap-1.5 h-full justify-end">
-                      <span className="text-[9px] font-extrabold text-slate-500">{bar.hrs}h</span>
+                      <span className="text-[10px] font-extrabold text-slate-500 sm:text-xs">{bar.hrs}h</span>
                       <div className="w-full bg-slate-100 rounded-t-lg h-20 flex items-end overflow-hidden">
                         <div
                           className={`w-full rounded-t-lg transition-all duration-500 ${bar.color}`}
                           style={{ height: bar.pct }}
                         />
                       </div>
-                      <span className="text-[9px] font-bold uppercase text-slate-400">{bar.day}</span>
+                      <span className="text-[10px] font-bold uppercase text-slate-400 sm:text-xs">{bar.day}</span>
                     </div>
                   ))}
                 </div>
@@ -1010,7 +1081,7 @@ export default function PrivateTimetablePage() {
 
               {/* Time Allocation Segmented Bar */}
               <div className="space-y-2">
-                <div className="flex justify-between text-[10px] font-extrabold text-slate-500">
+                <div className="flex justify-between text-[11px] font-extrabold text-slate-500 sm:text-xs">
                   <span>Semester Allocation</span>
                   <span>21 hrs / wk</span>
                 </div>
@@ -1019,7 +1090,7 @@ export default function PrivateTimetablePage() {
                   <div className="h-full w-[25%] bg-violet-400" title="Labs 25%" />
                   <div className="h-full w-[20%] rounded-r-full bg-[#DFFF61]" title="Study 20%" />
                 </div>
-                <div className="flex justify-between text-[9px] font-bold text-slate-500 pt-0.5">
+                <div className="flex justify-between text-[10px] font-bold text-slate-500 pt-0.5 sm:text-xs">
                   <span className="flex items-center gap-1">
                     <i className="h-2 w-2 rounded-full bg-[#0C60FC]" /> 55% Lectures
                   </span>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -16,6 +16,7 @@ import {
   type PlanDuration,
 } from "@/hooks/common/use-billing";
 import { toast } from "sonner";
+import { CreditBundleCard } from "@/components/common";
 
 const PRICES: Record<string, Record<PlanDuration, string>> = {
   cooked: { daily: "2.99", weekly: "4.99", semester: "14.99" },
@@ -336,112 +337,7 @@ export default function PricingPage() {
                     .join(" ");
 
                   return (
-                    <article
-                      key={bundle._id}
-                      className={`play-card relative flex w-full flex-col rounded-[28px] p-7 sm:w-[calc(50%-0.625rem)] lg:w-[calc(33.333%-0.833rem)] xl:w-[calc(25%-0.9375rem)] ${
-                        isBest
-                          ? "bg-slate-950 text-white shadow-2xl shadow-slate-900/30"
-                          : "border border-slate-200 bg-white text-slate-950"
-                      }`}
-                      style={{ borderRadius: "28px" }}
-                    >
-                      {isBest && (
-                        <span className="absolute -top-3 left-7 rounded-full bg-[#DFFF61] px-3 py-1 text-[10px] font-extrabold uppercase tracking-widest text-slate-900">
-                          Best value
-                        </span>
-                      )}
-                      {isStarter && (
-                        <span className="absolute -top-3 left-7 rounded-full bg-blue-100 px-3 py-1 text-[10px] font-extrabold uppercase tracking-widest text-blue-700">
-                          Starter
-                        </span>
-                      )}
-
-                      <div className="flex items-center gap-3">
-                        <span
-                          className={`flex h-11 w-11 items-center justify-center rounded-2xl ${
-                            isBest ? "bg-white/10" : "bg-slate-950"
-                          }`}
-                        >
-                          <Zap
-                            className={`h-5 w-5 text-[#DFFF61]`}
-                            strokeWidth={2.25}
-                          />
-                        </span>
-                        <div className="min-w-0">
-                          <p
-                            className={`text-[10px] font-extrabold uppercase tracking-widest ${
-                              isBest ? "text-[#DFFF61]" : "text-slate-500"
-                            }`}
-                          >
-                            Credit pack
-                          </p>
-                          <h3 className="display mt-0.5 text-lg font-bold">
-                            {displayName}
-                          </h3>
-                        </div>
-                      </div>
-
-                      <div className="mt-6">
-                        <div className="flex items-end gap-1">
-                          <span
-                            className={`text-xs font-bold ${
-                              isBest ? "text-slate-300" : "text-slate-400"
-                            }`}
-                          >
-                            GHS
-                          </span>
-                          <span className="display text-4xl font-bold">
-                            {bundle.priceGHS}
-                          </span>
-                        </div>
-                        <p
-                          className={`mt-1 text-xs font-semibold ${
-                            isBest ? "text-slate-300" : "text-slate-500"
-                          }`}
-                        >
-                          one-time · never expires
-                        </p>
-                      </div>
-
-                      <ul
-                        className={`mt-6 space-y-2.5 text-sm ${
-                          isBest ? "text-slate-100" : "text-slate-600"
-                        }`}
-                      >
-                        <li className="flex gap-2">
-                          <b className={isBest ? "text-[#DFFF61]" : "text-emerald-500"}>
-                            ✓
-                          </b>
-                          {bundle.credits} generation credits
-                        </li>
-                        <li className="flex gap-2">
-                          <b className={isBest ? "text-[#DFFF61]" : "text-emerald-500"}>
-                            ✓
-                          </b>
-                          GHS {perCredit.toFixed(2)} per credit
-                        </li>
-                        <li className="flex gap-2">
-                          <b className={isBest ? "text-[#DFFF61]" : "text-emerald-500"}>
-                            ✓
-                          </b>
-                          Works on any plan
-                        </li>
-                      </ul>
-
-                      <div className="mt-auto pt-7">
-                        <button
-                          type="button"
-                          onClick={() => handleBuyCreditBundle(bundle._id)}
-                          className={`squishy w-full rounded-2xl py-3.5 text-center text-sm font-extrabold transition ${
-                            isBest
-                              ? "bg-[#DFFF61] text-slate-900 hover:bg-white"
-                              : "bg-slate-950 text-white hover:bg-[#0C60FC]"
-                          }`}
-                        >
-                          Buy {bundle.credits} credits
-                        </button>
-                      </div>
-                    </article>
+                    <CreditBundleCard key={idx} bundle={bundle} index={idx} totalCount={creditBundles.length} onSelect={handleBuyCreditBundle} />
                   );
                 })}
               </div>

--- a/src/components/common/credit-bundle-card.tsx
+++ b/src/components/common/credit-bundle-card.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Zap } from "lucide-react";
+import type { CreditBundle } from "@/hooks/common/use-billing";
+
+interface CreditBundleCardProps {
+  bundle: CreditBundle;
+  index: number;
+  totalCount: number;
+  onSelect: (id: string) => void;
+}
+
+export function CreditBundleCard({
+  bundle,
+  index,
+  totalCount,
+  onSelect,
+}: CreditBundleCardProps) {
+  const isStarter = index === 0;
+  const isBest = index === totalCount - 1;
+
+  const priceGhs = Number(bundle.priceGHS);
+  const perCredit = bundle.credits > 0 ? priceGhs / bundle.credits : 0;
+
+  // Backend names come back lowercase ("starter pack"); title-case for display.
+  const displayName = bundle.name
+    .split(" ")
+    .map((w) => (w.length > 0 ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(" ");
+
+  return (
+    <article
+      className={`play-card relative flex w-full flex-col rounded-[28px] p-7 sm:w-[calc(50%-0.625rem)] lg:w-[calc(33.333%-0.833rem)] xl:w-[calc(25%-0.9375rem)] ${
+        isBest
+          ? "bg-slate-950 text-white shadow-2xl shadow-slate-900/30"
+          : "border border-slate-200 bg-white text-slate-950"
+      }`}
+      style={{ borderRadius: "28px" }}
+    >
+      {isBest && (
+        <span className="absolute -top-3 left-7 rounded-full bg-[#DFFF61] px-3 py-1 text-[10px] font-extrabold uppercase tracking-widest text-slate-900">
+          Best value
+        </span>
+      )}
+      {isStarter && (
+        <span className="absolute -top-3 left-7 rounded-full bg-blue-100 px-3 py-1 text-[10px] font-extrabold uppercase tracking-widest text-blue-700">
+          Starter
+        </span>
+      )}
+
+      <div className="flex items-center gap-3">
+        <span
+          className={`flex h-11 w-11 items-center justify-center rounded-2xl ${
+            isBest ? "bg-white/10" : "bg-slate-950"
+          }`}
+        >
+          <Zap className="h-5 w-5 text-[#DFFF61]" strokeWidth={2.25} />
+        </span>
+        <div className="min-w-0">
+          <p
+            className={`text-[10px] font-extrabold uppercase tracking-widest ${
+              isBest ? "text-[#DFFF61]" : "text-slate-500"
+            }`}
+          >
+            Credit pack
+          </p>
+          <h3 className="display mt-0.5 text-lg font-bold">{displayName}</h3>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <div className="flex items-end gap-1">
+          <span
+            className={`text-xs font-bold ${
+              isBest ? "text-slate-300" : "text-slate-400"
+            }`}
+          >
+            GHS
+          </span>
+          <span className="display text-4xl font-bold">{bundle.priceGHS}</span>
+        </div>
+        <p
+          className={`mt-1 text-xs font-semibold ${
+            isBest ? "text-slate-300" : "text-slate-500"
+          }`}
+        >
+          one-time · never expires
+        </p>
+      </div>
+
+      <ul
+        className={`mt-6 space-y-2.5 text-sm ${
+          isBest ? "text-slate-100" : "text-slate-600"
+        }`}
+      >
+        <li className="flex gap-2">
+          <b className={isBest ? "text-[#DFFF61]" : "text-emerald-500"}>✓</b>
+          {bundle.credits} generation credits
+        </li>
+        <li className="flex gap-2">
+          <b className={isBest ? "text-[#DFFF61]" : "text-emerald-500"}>✓</b>
+          GHS {perCredit.toFixed(2)} per credit
+        </li>
+        <li className="flex gap-2">
+          <b className={isBest ? "text-[#DFFF61]" : "text-emerald-500"}>✓</b>
+          Works on any plan
+        </li>
+      </ul>
+
+      <div className="mt-auto pt-7">
+        <button
+          type="button"
+          onClick={() => onSelect(bundle._id)}
+          className={`squishy w-full rounded-2xl py-3.5 text-center text-sm font-extrabold transition ${
+            isBest
+              ? "bg-[#DFFF61] text-slate-900 hover:bg-white"
+              : "bg-slate-950 text-white hover:bg-[#0C60FC]"
+          }`}
+        >
+          Buy {bundle.credits} credits
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -8,6 +8,7 @@ export * from "./user-profile-dropdown";
 export * from "./auth-guard";
 export * from "./cookie-consent";
 export * from "./plan-card";
+export * from "./credit-bundle-card";
 export * from "./referral-card";
 export * from "./json-ld";
 export * from "./MarkdownContent";


### PR DESCRIPTION
This pull request makes several improvements and adjustments across the billing, courses, quizzes, and timetable pages to enhance the user experience, update academic year and semester options, and improve mobile responsiveness. The most notable changes include refactoring the `CreditBundleCard` component, updating academic year and semester selections, and improving grid layouts and date selectors for better usability.

### Billing Page Improvements
* Refactored the `CreditBundleCard` component to import it from `@/components/common` instead of defining it locally, and updated its usage to pass additional props for index and total count. The display layout for credit bundles is now a responsive flexbox instead of a grid. [[1]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L15-R15) [[2]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L194-L223) [[3]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L393-R382)
* Improved readability and consistency of UI text by splitting long lines and clarifying plan and credit information. [[1]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L274-R251) [[2]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L310-R286) [[3]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L333-R314) [[4]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L366-R346) [[5]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L376-R364) [[6]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L413-R400) [[7]](diffhunk://#diff-ba2928699d3d9c7f687c481c4462d4e3ffb3947b3b2b3ea7e71b89d4d2c62ce9L426-R462)

### Courses Page Updates
* Updated academic years to only include future years (`2025-2026`, `2026-2027`) and removed "Summer Session" from semesters. The default selected year is now `2026-2027`. Past years are visually indicated with a strikethrough. [[1]](diffhunk://#diff-172a92f23311c6d9a1ab301e7b45f0181d363f91503954bc944f9aa73adedb90L30-R35) [[2]](diffhunk://#diff-172a92f23311c6d9a1ab301e7b45f0181d363f91503954bc944f9aa73adedb90L140-R158)
* Improved the empty state message for courses and adjusted grid layouts for better responsiveness. [[1]](diffhunk://#diff-172a92f23311c6d9a1ab301e7b45f0181d363f91503954bc944f9aa73adedb90L181-R185) [[2]](diffhunk://#diff-172a92f23311c6d9a1ab301e7b45f0181d363f91503954bc944f9aa73adedb90L215-R223)

### Quizzes Page Enhancement
* Updated the quizzes grid layout to use `sm:grid-cols-2` and `lg:grid-cols-3` for better responsiveness on different screen sizes.

### Timetable Page Improvements
* Added mobile detection to hide the "month" tab on mobile devices, improving navigation. [[1]](diffhunk://#diff-5fd762dfc50e0e7e4cf5a7df5f82fecfea2266811ce9c80952b618cb98438506R30) [[2]](diffhunk://#diff-5fd762dfc50e0e7e4cf5a7df5f82fecfea2266811ce9c80952b618cb98438506R187) [[3]](diffhunk://#diff-5fd762dfc50e0e7e4cf5a7df5f82fecfea2266811ce9c80952b618cb98438506L353-R356)
* Updated the date selector rail to use a 7-column grid and adjusted displayed days to include Saturday and Sunday, improving clarity and usability. [[1]](diffhunk://#diff-5fd762dfc50e0e7e4cf5a7df5f82fecfea2266811ce9c80952b618cb98438506L81-R83) [[2]](diffhunk://#diff-5fd762dfc50e0e7e4cf5a7df5f82fecfea2266811ce9c80952b618cb98438506L366-R378)