### PR TITLE
Admin features page for feature flag system

### DIFF
--- a/src/app/admin/(protected)/system/features/audit-modal.tsx
+++ b/src/app/admin/(protected)/system/features/audit-modal.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import {
+  History,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+} from "lucide-react";
+import { format } from "date-fns";
+import { cn } from "@/lib/utils";
+import {
+  FeatureFlag,
+  FeatureFlagAuditEntry,
+  useFeatureFlagAudit,
+} from "@/hooks/admin/use-feature-flags";
+
+interface AuditModalProps {
+  flag: FeatureFlag | null;
+  onClose: () => void;
+}
+
+const ACTION_STYLES: Record<string, string> = {
+  create: "border-green-500/40 text-green-500 bg-green-500/5",
+  enable: "border-green-500/40 text-green-500 bg-green-500/5",
+  disable: "border-yellow-500/40 text-yellow-500 bg-yellow-500/5",
+  update: "border-blue-500/40 text-blue-500 bg-blue-500/5",
+  delete: "border-destructive/40 text-destructive bg-destructive/5",
+};
+
+export function AuditModal({ flag, onClose }: AuditModalProps) {
+  const [page, setPage] = React.useState(1);
+
+  React.useEffect(() => {
+    setPage(1);
+  }, [flag?.key]);
+
+  const audit = useFeatureFlagAudit(flag?.key ?? null, page, 20);
+
+  return (
+    <Dialog open={!!flag} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="rounded-none border-border/50 bg-card/95 backdrop-blur-xl sm:max-w-[680px] max-h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-base uppercase tracking-[0.2em]">
+            Audit Log
+          </DialogTitle>
+          <DialogDescription className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+            {flag ? (
+              <>
+                <code className="text-primary">{flag.key}</code> · {flag.name}
+              </>
+            ) : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 min-h-0 overflow-y-auto pr-1">
+          {audit.isLoading ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground">
+              <Loader2 className="size-4 animate-spin mr-2" />
+              <span className="font-mono text-[10px] uppercase tracking-widest">
+                Loading audit history…
+              </span>
+            </div>
+          ) : !audit.data || audit.data.data.length === 0 ? (
+            <div className="py-12 text-center text-muted-foreground space-y-3">
+              <History className="size-8 text-muted-foreground/20 mx-auto" />
+              <p className="font-mono text-[10px] uppercase tracking-widest">
+                No audit entries yet.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {audit.data.data.map((entry) => (
+                <AuditEntry key={entry._id} entry={entry} />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {audit.data && audit.data.pagination.totalPages > 1 && (
+          <div className="flex items-center justify-between border-t border-border/30 pt-3">
+            <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+              Page {audit.data.pagination.page} / {audit.data.pagination.totalPages}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1 || audit.isFetching}
+                className="rounded-none size-8"
+              >
+                <ChevronLeft className="size-3.5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={() =>
+                  setPage((p) =>
+                    Math.min(audit.data!.pagination.totalPages, p + 1),
+                  )
+                }
+                disabled={
+                  page >= audit.data.pagination.totalPages || audit.isFetching
+                }
+                className="rounded-none size-8"
+              >
+                <ChevronRight className="size-3.5" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AuditEntry({ entry }: { entry: FeatureFlagAuditEntry }) {
+  const actionStyle =
+    ACTION_STYLES[entry.action] ??
+    "border-border text-muted-foreground bg-muted/20";
+
+  return (
+    <div className="border border-border/40 bg-background/40 p-4 space-y-2">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <span
+          className={cn(
+            "px-2 py-0.5 text-[9px] font-bold border uppercase tracking-widest",
+            actionStyle,
+          )}
+        >
+          {entry.action}
+        </span>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {format(new Date(entry.performedAt), "MMM dd, yyyy HH:mm:ss")}
+        </span>
+      </div>
+
+      {entry.reason && (
+        <p className="font-mono text-[11px] text-foreground leading-relaxed">
+          {entry.reason}
+        </p>
+      )}
+
+      <p className="font-mono text-[10px] text-muted-foreground">
+        By <code className="text-primary">{entry.performedBy}</code>
+      </p>
+
+      {entry.action === "update" && entry.after && (
+        <details className="font-mono text-[10px] text-muted-foreground">
+          <summary className="cursor-pointer hover:text-foreground uppercase tracking-widest">
+            Show changes
+          </summary>
+          <pre className="mt-2 p-3 bg-background/60 border border-border/30 overflow-x-auto whitespace-pre-wrap break-words">
+            {JSON.stringify(
+              diffBetween(entry.before ?? {}, entry.after ?? {}),
+              null,
+              2,
+            )}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function diffBetween(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): Record<string, { from: unknown; to: unknown }> {
+  const out: Record<string, { from: unknown; to: unknown }> = {};
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  keys.forEach((k) => {
+    const a = before[k];
+    const b = after[k];
+    if (JSON.stringify(a) !== JSON.stringify(b)) {
+      out[k] = { from: a, to: b };
+    }
+  });
+  return out;
+}

--- a/src/app/admin/(protected)/system/features/feature-flag-modal.tsx
+++ b/src/app/admin/(protected)/system/features/feature-flag-modal.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import {
+  CreateFlagBody,
+  FeatureFlag,
+  FlagType,
+  useCreateFeatureFlag,
+} from "@/hooks/admin/use-feature-flags";
+
+interface CreateFlagModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Optional pre-fill — when provided, the modal opens in "edit name/description" mode. */
+  initial?: Pick<FeatureFlag, "name" | "description">;
+  onCreated?: (created: FeatureFlag) => void;
+}
+
+const KEY_REGEX = /^[a-z][a-z0-9_]*$/;
+
+export function CreateFlagModal({
+  open,
+  onOpenChange,
+  initial,
+  onCreated,
+}: CreateFlagModalProps) {
+  const [key, setKey] = React.useState("");
+  const [name, setName] = React.useState(initial?.name ?? "");
+  const [description, setDescription] = React.useState(
+    initial?.description ?? "",
+  );
+  const [type, setType] = React.useState<FlagType>("boolean");
+  const [error, setError] = React.useState<string | null>(null);
+
+  const create = useCreateFeatureFlag();
+
+  // Reset on open.
+  React.useEffect(() => {
+    if (open) {
+      setKey("");
+      setName(initial?.name ?? "");
+      setDescription(initial?.description ?? "");
+      setType("boolean");
+      setError(null);
+    }
+  }, [open, initial?.name, initial?.description]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!KEY_REGEX.test(key)) {
+      setError(
+        "Key must start with a lowercase letter and use only lowercase letters, digits, and underscores.",
+      );
+      return;
+    }
+    if (!name.trim() || !description.trim()) {
+      setError("Name and description are required.");
+      return;
+    }
+
+    const body: CreateFlagBody = {
+      key,
+      name: name.trim(),
+      description: description.trim(),
+      type,
+      enabled: false,
+    };
+
+    try {
+      const created = await create.mutateAsync(body);
+      onCreated?.(created);
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to create feature flag.";
+      setError(msg);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="rounded-none border-border/50 bg-card/95 backdrop-blur-xl sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle className="font-mono text-base uppercase tracking-[0.2em]">
+            New Feature Flag
+          </DialogTitle>
+          <DialogDescription className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+            Flags start disabled. Toggle them on after creation.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+              Key
+            </Label>
+            <Input
+              value={key}
+              onChange={(e) => setKey(e.target.value)}
+              placeholder="my_feature_enabled"
+              className="rounded-none font-mono text-xs"
+              autoComplete="off"
+              spellCheck={false}
+              required
+            />
+            <p className="text-[10px] font-mono text-muted-foreground tracking-wide">
+              Identifier used in code: features.isEnabled(&quot;{key || "my_feature_enabled"}&quot;).
+              Cannot be changed later.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+              Display Name
+            </Label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="My Feature"
+              className="rounded-none font-mono text-xs"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+              Description
+            </Label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What this flag controls and why it exists."
+              className="rounded-none font-mono text-xs min-h-20"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+              Type
+            </Label>
+            <Select
+              value={type}
+              onValueChange={(v) => setType(v as FlagType)}
+            >
+              <SelectTrigger className="rounded-none font-mono text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="boolean" className="font-mono text-xs">
+                  boolean — master on/off switch
+                </SelectItem>
+                <SelectItem value="percentage" className="font-mono text-xs">
+                  percentage — rollout 0–100% (per-user hashing)
+                </SelectItem>
+                <SelectItem value="select" className="font-mono text-xs">
+                  select — one of a fixed list of options
+                </SelectItem>
+                <SelectItem value="json" className="font-mono text-xs">
+                  json — free-form config blob
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {error && (
+            <p className="text-[11px] font-mono text-destructive uppercase tracking-widest">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              className="rounded-none font-mono text-[10px] uppercase tracking-widest"
+              disabled={create.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="rounded-none font-mono text-[10px] uppercase tracking-widest"
+              disabled={create.isPending}
+            >
+              {create.isPending && (
+                <Loader2 className="size-3.5 animate-spin" />
+              )}
+              Create Flag
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/admin/(protected)/system/features/feature-flag-row.tsx
+++ b/src/app/admin/(protected)/system/features/feature-flag-row.tsx
@@ -1,0 +1,503 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+import { Switch } from "@/components/ui/switch";
+import { Slider } from "@/components/ui/slider";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  History,
+  MoreVertical,
+  Pencil,
+  Trash2,
+  Loader2,
+} from "lucide-react";
+import { format } from "date-fns";
+import { cn } from "@/lib/utils";
+import { toast } from "sonner";
+import {
+  FeatureFlag,
+  useDeleteFeatureFlag,
+  useUpdateFeatureFlag,
+} from "@/hooks/admin/use-feature-flags";
+
+interface FeatureFlagRowProps {
+  flag: FeatureFlag;
+  onViewAudit: (flag: FeatureFlag) => void;
+}
+
+export function FeatureFlagRow({ flag, onViewAudit }: FeatureFlagRowProps) {
+  const update = useUpdateFeatureFlag();
+  const remove = useDeleteFeatureFlag();
+
+  const [editOpen, setEditOpen] = React.useState(false);
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
+
+  // Local edit state — initialised from the flag, but the flag prop is the
+  // source of truth on save.
+  const [name, setName] = React.useState(flag.name);
+  const [description, setDescription] = React.useState(flag.description);
+  const [reason, setReason] = React.useState("");
+  const [deleteReason, setDeleteReason] = React.useState("");
+  const [editError, setEditError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (editOpen) {
+      setName(flag.name);
+      setDescription(flag.description);
+      setReason("");
+      setEditError(null);
+    }
+  }, [editOpen, flag.name, flag.description]);
+
+  const handleToggle = (next: boolean) => {
+    update.mutate(
+      { key: flag.key, body: { enabled: next, reason: reason || undefined } },
+      {
+        onSuccess: () => {
+          toast.success(
+            `Flag "${flag.key}" ${next ? "enabled" : "disabled"}.`,
+          );
+          setReason("");
+        },
+        onError: (err: unknown) => {
+          const msg =
+            err instanceof Error
+              ? err.message
+              : `Failed to update "${flag.key}".`;
+          toast.error(msg);
+        },
+      },
+    );
+  };
+
+  const handleSaveEdit = () => {
+    setEditError(null);
+    update.mutate(
+      {
+        key: flag.key,
+        body: {
+          name: name.trim(),
+          description: description.trim(),
+          reason: reason || undefined,
+        },
+      },
+      {
+        onSuccess: () => {
+          toast.success(`Flag "${flag.key}" updated.`);
+          setEditOpen(false);
+        },
+        onError: (err: unknown) => {
+          setEditError(
+            err instanceof Error ? err.message : "Failed to update flag.",
+          );
+        },
+      },
+    );
+  };
+
+  const handleDelete = () => {
+    remove.mutate(
+      { key: flag.key, reason: deleteReason || undefined },
+      {
+        onSuccess: () => {
+          toast.success(`Flag "${flag.key}" deleted.`);
+          setDeleteOpen(false);
+        },
+        onError: (err: unknown) => {
+          toast.error(
+            err instanceof Error ? err.message : "Failed to delete flag.",
+          );
+        },
+      },
+    );
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 4 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="group border border-border/50 bg-card/40 hover:border-border transition-colors"
+    >
+      <div className="grid grid-cols-1 md:grid-cols-[1fr,auto] gap-4 p-5">
+        {/* Left — meta + value editor */}
+        <div className="space-y-3 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-mono text-sm font-bold uppercase tracking-widest text-foreground truncate">
+              {flag.name}
+            </span>
+            <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground px-1.5 py-0.5 border border-border/50 bg-background/50">
+              {flag.type}
+            </span>
+            <code className="font-mono text-[10px] text-primary tracking-wide bg-primary/5 px-1.5 py-0.5 border border-primary/20">
+              {flag.key}
+            </code>
+            <span
+              className={cn(
+                "size-1.5 rounded-full",
+                flag.enabled ? "bg-green-500" : "bg-muted-foreground/40",
+              )}
+              title={flag.enabled ? "Enabled" : "Disabled"}
+            />
+          </div>
+
+          <p className="text-xs font-mono text-muted-foreground leading-relaxed">
+            {flag.description}
+          </p>
+
+          <ValueEditor flag={flag} />
+        </div>
+
+        {/* Right — controls */}
+        <div className="flex md:flex-col items-start md:items-end justify-between md:justify-start gap-3 shrink-0">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="rounded-none size-7"
+              >
+                <MoreVertical className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="rounded-none">
+              <DropdownMenuItem
+                onClick={() => setEditOpen(true)}
+                className="font-mono text-[11px] uppercase tracking-widest"
+              >
+                <Pencil className="size-3.5" />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onViewAudit(flag)}
+                className="font-mono text-[11px] uppercase tracking-widest"
+              >
+                <History className="size-3.5" />
+                Audit Log
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => setDeleteOpen(true)}
+                className="font-mono text-[11px] uppercase tracking-widest text-destructive focus:text-destructive"
+              >
+                <Trash2 className="size-3.5" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <div className="flex flex-col items-end gap-2">
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "font-mono text-[9px] uppercase tracking-widest",
+                  flag.enabled ? "text-green-500" : "text-muted-foreground",
+                )}
+              >
+                {flag.enabled ? "On" : "Off"}
+              </span>
+              <Switch
+                checked={flag.enabled}
+                onCheckedChange={handleToggle}
+                disabled={update.isPending}
+              />
+            </div>
+            <p className="font-mono text-[9px] text-muted-foreground tracking-widest uppercase">
+              {format(new Date(flag.updatedAt), "MMM dd, HH:mm")}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Edit modal */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent className="rounded-none border-border/50 bg-card/95 backdrop-blur-xl sm:max-w-[560px]">
+          <DialogHeader>
+            <DialogTitle className="font-mono text-base uppercase tracking-[0.2em]">
+              Edit Flag
+            </DialogTitle>
+            <DialogDescription className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+              <code className="text-primary">{flag.key}</code> · {flag.type}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                Display Name
+              </Label>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="rounded-none font-mono text-xs"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                Description
+              </Label>
+              <Textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                className="rounded-none font-mono text-xs min-h-20"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+                Reason (optional, written to audit log)
+              </Label>
+              <Input
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="Why are you making this change?"
+                className="rounded-none font-mono text-xs"
+              />
+            </div>
+
+            {editError && (
+              <p className="text-[11px] font-mono text-destructive uppercase tracking-widest">
+                {editError}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setEditOpen(false)}
+              className="rounded-none font-mono text-[10px] uppercase tracking-widest"
+              disabled={update.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleSaveEdit}
+              className="rounded-none font-mono text-[10px] uppercase tracking-widest"
+              disabled={update.isPending}
+            >
+              {update.isPending && (
+                <Loader2 className="size-3.5 animate-spin" />
+              )}
+              Save Changes
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation */}
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="rounded-none border-border/50 bg-card/95 backdrop-blur-xl sm:max-w-[480px]">
+          <DialogHeader>
+            <DialogTitle className="font-mono text-base uppercase tracking-[0.2em] text-destructive">
+              Delete Flag
+            </DialogTitle>
+            <DialogDescription className="font-mono text-[11px] uppercase tracking-widest text-muted-foreground">
+              This removes the flag and its audit history. Any code that reads
+              it will fall back to disabled.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+              Reason (optional)
+            </Label>
+            <Input
+              value={deleteReason}
+              onChange={(e) => setDeleteReason(e.target.value)}
+              placeholder="e.g. feature shipped to GA"
+              className="rounded-none font-mono text-xs"
+            />
+            <p className="font-mono text-[10px] text-muted-foreground">
+              Deleting{" "}
+              <code className="text-primary">{flag.key}</code> cannot be undone
+              via the UI.
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteOpen(false)}
+              className="rounded-none font-mono text-[10px] uppercase tracking-widest"
+              disabled={remove.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              className="rounded-none font-mono text-[10px] uppercase tracking-widest"
+              disabled={remove.isPending}
+            >
+              {remove.isPending && (
+                <Loader2 className="size-3.5 animate-spin" />
+              )}
+              Delete Flag
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </motion.div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-type value editor — percentage slider, select dropdown, json textarea.
+// Boolean: no value editor (master switch is the row's Switch).
+// ---------------------------------------------------------------------------
+
+interface ValueEditorProps {
+  flag: FeatureFlag;
+}
+
+function ValueEditor({ flag }: ValueEditorProps) {
+  const update = useUpdateFeatureFlag();
+
+  if (flag.type === "boolean") {
+    return (
+      <p className="font-mono text-[10px] text-muted-foreground uppercase tracking-widest">
+        Master switch — no extra value.
+      </p>
+    );
+  }
+
+  if (flag.type === "percentage") {
+    const current = typeof flag.value === "number" ? flag.value : 0;
+    const onChange = (next: number) => {
+      update.mutate({ key: flag.key, body: { value: next } });
+    };
+    return (
+      <div className="space-y-2 max-w-md">
+        <div className="flex items-center justify-between">
+          <span className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+            Rollout
+          </span>
+          <span className="font-mono text-xs font-bold text-foreground">
+            {current}%
+          </span>
+        </div>
+        <Slider
+          value={[current]}
+          min={0}
+          max={100}
+          step={1}
+          onValueCommit={(v) => onChange(v[0])}
+          className="w-full"
+        />
+        <p className="font-mono text-[10px] text-muted-foreground">
+          Per-user hashing: FNV-1a(key+userId) % 100. Same users stay bucketed.
+        </p>
+      </div>
+    );
+  }
+
+  if (flag.type === "select") {
+    const options = flag.options ?? [];
+    const current = typeof flag.value === "string" ? flag.value : "";
+    return (
+      <div className="space-y-2 max-w-md">
+        <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+          Selected Value
+        </Label>
+        <Select
+          value={current}
+          onValueChange={(v) =>
+            update.mutate({ key: flag.key, body: { value: v } })
+          }
+        >
+          <SelectTrigger className="rounded-none font-mono text-xs">
+            <SelectValue placeholder="(unset)" />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((opt) => (
+              <SelectItem key={opt} value={opt} className="font-mono text-xs">
+                {opt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  }
+
+  // json
+  const stringified = JSON.stringify(flag.config ?? {}, null, 2);
+  const [text, setText] = React.useState(stringified);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setText(stringified);
+    setError(null);
+  }, [stringified, flag.key]);
+
+  const commit = () => {
+    setError(null);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Invalid JSON");
+      return;
+    }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      setError("Config must be a JSON object.");
+      return;
+    }
+    update.mutate({
+      key: flag.key,
+      body: { config: parsed as Record<string, unknown> },
+    });
+  };
+
+  return (
+    <div className="space-y-2 max-w-md">
+      <Label className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+        Config (JSON)
+      </Label>
+      <Textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+        className="rounded-none font-mono text-xs min-h-24"
+        spellCheck={false}
+      />
+      {error && (
+        <p className="font-mono text-[10px] text-destructive uppercase tracking-widest">
+          {error}
+        </p>
+      )}
+      <p className="font-mono text-[10px] text-muted-foreground">
+        Saved on blur.
+      </p>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/system/features/page.tsx
+++ b/src/app/admin/(protected)/system/features/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+import { Flag, Plus, RefreshCcw, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import {
+  FeatureFlag,
+  useFeatureFlags,
+} from "@/hooks/admin/use-feature-flags";
+import { useAuth } from "@/contexts/auth-context";
+import { FeatureFlagRow } from "./feature-flag-row";
+import { CreateFlagModal } from "./feature-flag-modal";
+import { AuditModal } from "./audit-modal";
+
+export default function FeatureFlagsPage() {
+  const { data: flags, isLoading, refetch } = useFeatureFlags();
+  const { user } = useAuth();
+  const isSuperAdmin = user?.role === "super_admin";
+
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [auditFlag, setAuditFlag] = React.useState<FeatureFlag | null>(null);
+
+  const summary = React.useMemo(() => {
+    const total = flags?.length ?? 0;
+    const enabled = flags?.filter((f) => f.enabled).length ?? 0;
+    const byType: Record<string, number> = {};
+    flags?.forEach((f) => {
+      byType[f.type] = (byType[f.type] ?? 0) + 1;
+    });
+    return { total, enabled, byType };
+  }, [flags]);
+
+  if (!isSuperAdmin) {
+    return <ForbiddenNotice />;
+  }
+
+  return (
+    <div className="space-y-8">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+      >
+        <div className="inline-block border border-primary/60 px-2 py-1 mb-3 bg-primary/5">
+          <span className="text-[10px] font-mono tracking-widest uppercase text-primary">
+            System
+          </span>
+        </div>
+
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+          <div>
+            <h1 className="text-3xl font-mono font-bold tracking-[0.2em] uppercase text-foreground">
+              Feature Flags
+            </h1>
+            <p className="text-xs font-mono text-muted-foreground mt-1 tracking-widest uppercase">
+              Runtime Toggles &amp; Rollouts
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => refetch()}
+              className="rounded-none size-9"
+              disabled={isLoading}
+            >
+              <RefreshCcw
+                className={cn("size-4", isLoading && "animate-spin")}
+              />
+            </Button>
+            <Button
+              onClick={() => setCreateOpen(true)}
+              className="rounded-none font-mono text-[10px] tracking-widest uppercase gap-2 h-9 px-4"
+            >
+              <Plus className="size-3.5" />
+              New Flag
+            </Button>
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Summary */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <SummaryStat
+          label="Total Flags"
+          value={summary.total}
+          accent="text-foreground"
+        />
+        <SummaryStat
+          label="Enabled"
+          value={summary.enabled}
+          accent="text-green-500"
+        />
+        <SummaryStat
+          label="Disabled"
+          value={summary.total - summary.enabled}
+          accent="text-muted-foreground"
+        />
+        <SummaryStat
+          label="Types"
+          value={Object.keys(summary.byType).length}
+          accent="text-primary"
+        />
+      </div>
+
+      {/* Flag list */}
+      {isLoading ? (
+        <div className="border border-border/40 bg-card/40 p-12 text-center text-muted-foreground font-mono text-[10px] uppercase tracking-widest animate-pulse">
+          Loading feature flags…
+        </div>
+      ) : !flags || flags.length === 0 ? (
+        <Card className="rounded-none border-border/50 bg-card/40">
+          <CardContent className="p-12 text-center space-y-3">
+            <Flag className="size-10 text-muted-foreground/30 mx-auto" />
+            <p className="font-mono text-xs uppercase tracking-widest text-foreground">
+              No feature flags yet
+            </p>
+            <p className="font-mono text-[10px] text-muted-foreground max-w-sm mx-auto">
+              Migration 049 seeds the starter flags. If you see zero rows,
+              re-run the migration or create one manually.
+            </p>
+            <Button
+              onClick={() => setCreateOpen(true)}
+              className="rounded-none font-mono text-[10px] uppercase tracking-widest mt-2"
+            >
+              <Plus className="size-3.5" />
+              Create First Flag
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {flags.map((flag) => (
+            <FeatureFlagRow
+              key={flag.key}
+              flag={flag}
+              onViewAudit={setAuditFlag}
+            />
+          ))}
+        </div>
+      )}
+
+      <CreateFlagModal
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        onCreated={(created) => {
+          setAuditFlag(created);
+        }}
+      />
+
+      <AuditModal flag={auditFlag} onClose={() => setAuditFlag(null)} />
+    </div>
+  );
+}
+
+function SummaryStat({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent: string;
+}) {
+  return (
+    <Card className="rounded-none border-border/50 bg-card/40">
+      <CardContent className="pt-6">
+        <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground">
+          {label}
+        </p>
+        <p className={cn("text-2xl font-mono font-bold mt-2", accent)}>
+          {value}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ForbiddenNotice() {
+  return (
+    <div className="border border-destructive/40 bg-destructive/5 p-8 rounded-none flex items-start gap-3 max-w-2xl">
+      <ShieldCheck className="size-5 text-destructive shrink-0 mt-0.5" />
+      <div className="space-y-1">
+        <p className="font-mono text-sm uppercase tracking-widest font-bold text-destructive">
+          Super Admin Only
+        </p>
+        <p className="font-mono text-xs text-muted-foreground">
+          The feature flag system can change runtime behaviour across the whole
+          platform. It is gated to{" "}
+          <code className="text-foreground">super_admin</code> by design. If
+          you need access, ask a super admin to promote your role.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/admin-sidebar.tsx
+++ b/src/components/admin/admin-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   CreditCard,
   Library,
   Zap,
+  Flag,
 } from "lucide-react";
 import { useAuth } from "@/contexts/auth-context";
 import {
@@ -129,8 +130,13 @@ const navigation = [
     ],
   },
   {
-    title: "Infrastructure",
+    title: "System",
     items: [
+      {
+        title: "Feature Flags",
+        url: "/admin/system/features",
+        icon: Flag,
+      },
       {
         title: "Migrations",
         url: "/admin/migrations",

--- a/src/hooks/admin/index.ts
+++ b/src/hooks/admin/index.ts
@@ -3,3 +3,4 @@ export * from "./use-academics";
 export * from "./use-migrations";
 export * from "./use-admin-library";
 export * from "./use-public-generation";
+export * from "./use-feature-flags";

--- a/src/hooks/admin/use-feature-flags.ts
+++ b/src/hooks/admin/use-feature-flags.ts
@@ -1,0 +1,225 @@
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+// ---------------------------------------------------------------------------
+// Types — mirror the backend's `IFeatureFlag` / `IFeatureFlagAudit` shapes
+// after a `.lean()` round-trip (string IDs, optional fields as null).
+// ---------------------------------------------------------------------------
+
+export type FlagType = "boolean" | "percentage" | "select" | "json";
+
+export type FlagAuditAction =
+  | "create"
+  | "update"
+  | "delete"
+  | "enable"
+  | "disable";
+
+export interface FeatureFlag {
+  _id: string;
+  key: string;
+  name: string;
+  description: string;
+  type: FlagType;
+  enabled: boolean;
+  value?: number | string | null;
+  options?: string[] | null;
+  config?: Record<string, unknown> | null;
+  updatedAt: string;
+  createdAt: string;
+  updatedBy?: string | null;
+}
+
+export interface FeatureFlagAuditEntry {
+  _id: string;
+  flagKey: string;
+  action: FlagAuditAction;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  performedBy: string;
+  performedAt: string;
+  reason?: string | null;
+}
+
+export interface AuditPage {
+  data: FeatureFlagAuditEntry[];
+  pagination: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// List — fetches every flag (admin-only endpoint).
+// ---------------------------------------------------------------------------
+
+export const useFeatureFlags = () =>
+  useQuery({
+    queryKey: ["admin", "features"],
+    queryFn: async () => {
+      const { data } = await api.get<{ data: FeatureFlag[] }>(
+        "/admin/system/features",
+      );
+      return data.data;
+    },
+    staleTime: 30_000,
+  });
+
+// ---------------------------------------------------------------------------
+// Toggle — optimistic. We flip `enabled` in the cache before the round-trip
+// so the switch feels instant; on error we roll back and toast.
+// ---------------------------------------------------------------------------
+
+interface UpdateFlagBody {
+  name?: string;
+  description?: string;
+  enabled?: boolean;
+  value?: number | string | null;
+  options?: string[] | null;
+  config?: Record<string, unknown> | null;
+  reason?: string;
+}
+
+export const useUpdateFeatureFlag = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      key,
+      body,
+    }: {
+      key: string;
+      body: UpdateFlagBody;
+    }) => {
+      const { data } = await api.patch<{ data: FeatureFlag }>(
+        `/admin/system/features/${key}`,
+        body,
+      );
+      return data.data;
+    },
+    // Optimistic update — flip the cached flag immediately.
+    onMutate: async ({ key, body }) => {
+      await queryClient.cancelQueries({ queryKey: ["admin", "features"] });
+      const previous = queryClient.getQueryData<FeatureFlag[]>([
+        "admin",
+        "features",
+      ]);
+      if (previous) {
+        queryClient.setQueryData<FeatureFlag[]>(
+          ["admin", "features"],
+          previous.map((f) =>
+            f.key === key
+              ? {
+                  ...f,
+                  ...("enabled" in body ? { enabled: !!body.enabled } : {}),
+                  ...("value" in body ? { value: body.value ?? null } : {}),
+                  ...("options" in body ? { options: body.options ?? null } : {}),
+                  ...("config" in body ? { config: body.config ?? null } : {}),
+                  ...("name" in body && body.name ? { name: body.name } : {}),
+                  ...("description" in body && body.description !== undefined
+                    ? { description: body.description }
+                    : {}),
+                }
+              : f,
+          ),
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(["admin", "features"], ctx.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "features"] });
+    },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Create — new flag from scratch. Super-admin only.
+// ---------------------------------------------------------------------------
+
+export interface CreateFlagBody {
+  key: string;
+  name: string;
+  description: string;
+  type: FlagType;
+  enabled?: boolean;
+  value?: number | string | null;
+  options?: string[];
+  config?: Record<string, unknown>;
+  reason?: string;
+}
+
+export const useCreateFeatureFlag = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (body: CreateFlagBody) => {
+      const { data } = await api.post<{ data: FeatureFlag }>(
+        "/admin/system/features",
+        body,
+      );
+      return data.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "features"] });
+    },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Delete — removes a flag entirely (and its audit history).
+// ---------------------------------------------------------------------------
+
+export const useDeleteFeatureFlag = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      key,
+      reason,
+    }: {
+      key: string;
+      reason?: string;
+    }) => {
+      await api.delete(`/admin/system/features/${key}`, {
+        data: reason ? { reason } : undefined,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "features"] });
+    },
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Audit history — paginated by flag key.
+// ---------------------------------------------------------------------------
+
+export const useFeatureFlagAudit = (
+  key: string | null,
+  page: number,
+  limit = 20,
+) =>
+  useQuery({
+    queryKey: ["admin", "features", "audit", key, page, limit],
+    queryFn: async () => {
+      const { data } = await api.get<{ data: AuditPage }>(
+        `/admin/system/features/${key}/audit`,
+        { params: { page, limit } },
+      );
+      return data.data;
+    },
+    enabled: !!key,
+    placeholderData: keepPreviousData,
+  });


### PR DESCRIPTION
UI for the new admin-managed feature flag system (backend: BBF-Labs/quizzes_backend#216).

Adds /admin/system/features, gated to super_admin in-UI (backend enforces it too):

- List of flags with status dot, type badge, last-updated timestamp.
- Per-type value editor: percentage slider (live commit on release), select dropdown, JSON textarea with on-blur save.
- Optimistic master switch.
- Create / edit / delete modals, both with optional reason text written to the audit log.
- Paginated audit modal with before/after diff for update actions.
- Empty-state nudge pointing at migration 049 if zero flags exist.
- Summary stats (total / enabled / disabled / types).
- Forbidden notice for non-super-admin users.
- Sidebar: new System group containing Feature Flags + existing Migrations entry.

Hooks: src/hooks/admin/use-feature-flags.ts (list, optimistic toggle, create, delete, paginated audit). All TanStack Query.