### PR TITLE
feat(session, stream): delivered message state fix, update study plan mutation, and step continue handling

### DIFF
--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -281,12 +281,11 @@ export default function ChatPage() {
 
   // Step advancement handler for Continue / Keep going button
   const handleContinue = useCallback(() => {
-    if (messages.length === 0) {
-      if (sessionStep < 2) {
-        setSessionStep((prev) => prev + 1);
-        window.scrollTo({ top: 0, behavior: "smooth" });
-      }
-    } else {
+    if (sessionStep < 2) {
+      setSessionStep((prev) => prev + 1);
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+    if (messages.length > 0) {
       // If recap is active, send "Keep going", otherwise "Continue"
       sendMessage(isRecapActive ? "Keep going" : "Continue", undefined, true);
     }

--- a/src/components/app/center/MessageFeed.tsx
+++ b/src/components/app/center/MessageFeed.tsx
@@ -121,8 +121,8 @@ export function MessageFeed({
     return "";
   }, [messages, activeTopic]);
 
-  // Step 0: Overview Accordion Card
-  if (sessionStep === 0) {
+  // Step 0: Overview Accordion Card (Initial launch only when no messages exist)
+  if (sessionStep === 0 && messages.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center gap-5 py-4 px-4 sm:px-6 max-w-xl w-full mx-auto pb-32">
         <motion.div
@@ -164,8 +164,8 @@ export function MessageFeed({
     );
   }
 
-  // Step 1: Knowledge Pathway with thinking state
-  if (sessionStep === 1) {
+  // Step 1: Knowledge Pathway with thinking state (Initial launch only when no messages exist)
+  if (sessionStep === 1 && messages.length === 0) {
     return (
       <div className="flex flex-1 flex-col items-center gap-5 py-4 px-4 sm:px-6 max-w-xl w-full mx-auto pb-32">
         <motion.div
@@ -231,7 +231,8 @@ export function MessageFeed({
   }
 
   const lastMessage = messages[messages.length - 1];
-  const isAiStreaming = !!lastMessage?.isStreaming;
+  const isAiThinking = !!lastMessage?.isThinking;
+  const isAiStreaming = !!lastMessage?.isStreaming || isAiThinking;
   const isUserTurn = lastMessage?.role === "user" && !isAiStreaming;
 
   return (
@@ -239,7 +240,7 @@ export function MessageFeed({
       {/* Gliding animated orb tracking the current active turn & typing */}
       <div className="w-full flex justify-start sticky top-2 z-20 pointer-events-none pl-2">
         <GlowingOrb
-          isThinking={isAiStreaming}
+          isThinking={isAiStreaming || isAiThinking}
           isTyping={isTyping}
           inputLength={inputLength}
           position={isUserTurn ? "user" : "ai"}

--- a/src/components/app/layout/app-session-layout.tsx
+++ b/src/components/app/layout/app-session-layout.tsx
@@ -223,7 +223,9 @@ export function AppSessionLayout({ children, sessionId }: AppSessionLayoutProps)
           sessionId,
           message: trimmed,
         });
+        stream.updateMessage(userMsgId, { status: "sent" });
       } catch (err: unknown) {
+        stream.updateMessage(userMsgId, { status: "error" });
         const errorMsg =
           err instanceof Error
             ? err.message

--- a/src/components/app/session/UpdateStudyPlanView.tsx
+++ b/src/components/app/session/UpdateStudyPlanView.tsx
@@ -21,6 +21,7 @@ import {
   useAddChapter,
   useAddChapterGoal,
   useToggleBlockCompletion,
+  useGenerateStudyPlan,
 } from "@/hooks/app/use-app-actions";
 import type { IChapter, IKnowledgeBlock } from "@/types/session";
 import { toast } from "sonner";
@@ -49,6 +50,7 @@ export function UpdateStudyPlanView({
 }: UpdateStudyPlanViewProps) {
   const { data: app } = useApp(sessionId || "");
   const sendMessageMutation = useAppMessage();
+  const generatePlanMutation = useGenerateStudyPlan(sessionId || "");
   const addChapterMutation = useAddChapter(sessionId || "");
   const addGoalMutation = useAddChapterGoal(sessionId || "");
   const toggleBlockMutation = useToggleBlockCompletion(sessionId || "");
@@ -103,11 +105,17 @@ export function UpdateStudyPlanView({
 
     if (sessionId) {
       try {
-        await sendMessageMutation.mutateAsync({
-          sessionId,
-          message: text,
-        });
-        toast.success("Study plan directive sent to Z");
+        await Promise.allSettled([
+          generatePlanMutation.mutateAsync({
+            goal: app?.studyPlan?.goal,
+            instruction: text,
+          }),
+          sendMessageMutation.mutateAsync({
+            sessionId,
+            message: `Please update the study plan: ${text}`,
+          }),
+        ]);
+        toast.success("Study plan update requested from Z");
       } catch {
         toast.error("Failed to send instruction to Z");
       }

--- a/src/hooks/app/use-app-actions.ts
+++ b/src/hooks/app/use-app-actions.ts
@@ -797,8 +797,12 @@ export const useGenerateStudyPlan = (sessionId: string) => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (goal?: string) => {
-      const response = await api.post(`/app/${sessionId}/study-plan/generate`, { goal });
+    mutationFn: async (payload?: { goal?: string; instruction?: string } | string) => {
+      const body =
+        typeof payload === "string"
+          ? { goal: payload }
+          : payload || {};
+      const response = await api.post(`/app/${sessionId}/study-plan/generate`, body);
       return response.data;
     },
     onSuccess: () => {

--- a/src/hooks/app/use-app-stream.ts
+++ b/src/hooks/app/use-app-stream.ts
@@ -103,10 +103,10 @@ export const useAppStream = (
           if (!contentMatch) {
             next.push(im);
             changed = true;
-          } else if (!contentMatch.messageId && im.messageId) {
-            // Update local optimistic message with server's messageId
+          } else {
+            // Update local optimistic message with server's message and mark delivered
             const idx = next.indexOf(contentMatch);
-            next[idx] = { ...contentMatch, ...im };
+            next[idx] = { ...contentMatch, ...im, status: "sent" };
             changed = true;
           }
         }
@@ -167,6 +167,71 @@ export const useAppStream = (
       try {
         switch (signal.type) {
           case "thinking_chunk":
+            if (
+              signal.payload?.text !== undefined ||
+              signal.payload?.chunk !== undefined
+            ) {
+              const thoughtChunk =
+                signal.payload?.chunk ?? signal.payload?.text ?? "";
+              const msgId = signal.payload?.messageId;
+
+              setMessages((prev) => {
+                const msgs = [...prev];
+                const existingIdx = msgId
+                  ? msgs.findIndex(
+                      (m) => m.messageId === msgId || m.id === msgId,
+                    )
+                  : -1;
+
+                if (existingIdx >= 0) {
+                  streamingMessageIds.current.add(msgId!);
+                  msgs[existingIdx] = {
+                    ...msgs[existingIdx],
+                    isThinking: true,
+                    isStreaming: true,
+                    thinkingContent:
+                      (msgs[existingIdx].thinkingContent || "") + thoughtChunk,
+                  };
+                } else {
+                  const stableId = msgId || uuidv4();
+                  streamingMessageIds.current.add(stableId);
+                  const newMsg: ZAppMessage = {
+                    id: stableId,
+                    messageId: stableId,
+                    role: "z",
+                    type: "text" as ZAppMessageType,
+                    content: "",
+                    thinkingContent: thoughtChunk,
+                    timestamp: signal.timestamp || new Date().toISOString(),
+                    isStreaming: true,
+                    isThinking: true,
+                  };
+                  if (isMountedRef.current) {
+                    msgs.push(newMsg);
+                  }
+                }
+                return msgs;
+              });
+            }
+            break;
+
+          case "thinking_done": {
+            const doneId = signal.payload?.messageId as string | undefined;
+            if (doneId) {
+              setMessages((prev) => {
+                const msgs = [...prev];
+                const idx = msgs.findIndex(
+                  (m) => m.id === doneId || m.messageId === doneId,
+                );
+                if (idx >= 0) {
+                  msgs[idx] = { ...msgs[idx], isThinking: false };
+                }
+                return msgs;
+              });
+            }
+            break;
+          }
+
           case "text_chunk":
             if (
               signal.payload?.text !== undefined ||
@@ -189,6 +254,7 @@ export const useAppStream = (
                     ...msgs[existingIdx],
                     content: msgs[existingIdx].content + text,
                     isStreaming: true,
+                    isThinking: false,
                   };
                 } else {
                   const stableId = msgId || uuidv4();
@@ -201,6 +267,7 @@ export const useAppStream = (
                     content: text,
                     timestamp: signal.timestamp || new Date().toISOString(),
                     isStreaming: true,
+                    isThinking: false,
                   };
                   if (isMountedRef.current) {
                     msgs.push(newMsg);
@@ -211,7 +278,6 @@ export const useAppStream = (
             }
             break;
 
-          case "thinking_done":
           case "text_done": {
             const doneId = signal.payload?.messageId as string | undefined;
             if (doneId) {
@@ -222,7 +288,11 @@ export const useAppStream = (
                   (m) => m.id === doneId || m.messageId === doneId,
                 );
                 if (idx >= 0) {
-                  msgs[idx] = { ...msgs[idx], isStreaming: false };
+                  msgs[idx] = {
+                    ...msgs[idx],
+                    isStreaming: false,
+                    isThinking: false,
+                  };
                 }
                 return msgs;
               });

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -199,6 +199,8 @@ export interface ZAppMessage {
   toolResult?: unknown;
   mode?: string;
   isStreaming?: boolean;
+  isThinking?: boolean;
+  thinkingContent?: string;
   status?: "sending" | "sent" | "error";
   replyToMessageId?: string;
   rating?: 1 | -1;
@@ -399,6 +401,7 @@ export interface IStudyPlan {
   sessionId?: string;
   userId?: string;
   courseId?: string;
+  goal?: string;
   chapters: IChapter[];
   totalBlocks: number;
   completedBlocks: number;


### PR DESCRIPTION
This pull request introduces several improvements to the chat session experience, focusing on better handling of AI "thinking" states, improved study plan update logic, and enhanced message status tracking. The changes ensure a smoother user experience by making the UI more responsive to backend signals and providing clearer feedback during study plan updates.

**AI Thinking & Streaming State Handling:**

- Added `isThinking` and `thinkingContent` properties to the `ZAppMessage` type, and updated the message streaming logic to handle new backend "thinking" signals, allowing the UI to display when the AI is thinking separately from when it is streaming a response. This includes handling `thinking_chunk` and `thinking_done` signals and updating message state accordingly. [[1]](diffhunk://#diff-51f97b742de30bb162702ea1229aa6314df6664936c65c03496271b07c211264R202-R203) [[2]](diffhunk://#diff-c2608edb7a99c014be3fe409f89d620c02e61249d7f6ba88e7f3477da8da9ff7R170-R234) [[3]](diffhunk://#diff-c2608edb7a99c014be3fe409f89d620c02e61249d7f6ba88e7f3477da8da9ff7R257) [[4]](diffhunk://#diff-c2608edb7a99c014be3fe409f89d620c02e61249d7f6ba88e7f3477da8da9ff7R270) [[5]](diffhunk://#diff-c2608edb7a99c014be3fe409f89d620c02e61249d7f6ba88e7f3477da8da9ff7L225-R295)
- Updated the `MessageFeed` component and the glowing orb indicator to reflect both AI thinking and streaming states, providing better visual feedback to users.

**Message Status Tracking:**

- Improved message status updates by marking messages as "sent" or "error" based on the result of sending, and updating optimistic messages with server responses. [[1]](diffhunk://#diff-32667235572e11ef6188cf6e2a3af875c287722c6018c464e636cd6a969d0a71R226-R228) [[2]](diffhunk://#diff-c2608edb7a99c014be3fe409f89d620c02e61249d7f6ba88e7f3477da8da9ff7L106-R109)

**Study Plan Update Workflow:**

- Enhanced the study plan update process to send both a study plan generation request and a chat message simultaneously, and updated the mutation logic to support both goal and instruction fields. This ensures that study plan updates are processed more robustly and user feedback is clearer. [[1]](diffhunk://#diff-b62961257e7cf030ff260b5138622fd53f4b32ab7442b25d85da315a47dd10abR24) [[2]](diffhunk://#diff-b62961257e7cf030ff260b5138622fd53f4b32ab7442b25d85da315a47dd10abR53) [[3]](diffhunk://#diff-b62961257e7cf030ff260b5138622fd53f4b32ab7442b25d85da315a47dd10abL106-R118) [[4]](diffhunk://#diff-a3ecf19b908ca2258716ddac85b0b9170915ae66c2f435265fa136f70cc6fad7L800-R805) [[5]](diffhunk://#diff-51f97b742de30bb162702ea1229aa6314df6664936c65c03496271b07c211264R404)

**UI Behavior Improvements:**

- Adjusted the logic in `MessageFeed` to only show the overview and knowledge pathway cards on initial launch when there are no messages, preventing unwanted UI states as the session progresses. [[1]](diffhunk://#diff-e676a852e9523c6d5a8b10b7ea663fc5934ef17b9b2827a1e6bb6762c285a37eL124-R125) [[2]](diffhunk://#diff-e676a852e9523c6d5a8b10b7ea663fc5934ef17b9b2827a1e6bb6762c285a37eL167-R168)
- Refined the step advancement handler to ensure correct behavior when continuing through session steps, especially when messages exist. ([src/app/app/[id]/page.tsxL284-R288](diffhunk://#diff-d84e312912b46897f32c24697740b97d56f2e00ce410aae583d49bfc208dc0f4L284-R288))