### PR TITLE
[fix]: wire explicit Grade with Z into quiz results

### DIFF
--- a/src/app/app/quizzes/[id]/take/page.tsx
+++ b/src/app/app/quizzes/[id]/take/page.tsx
@@ -113,6 +113,8 @@ export default function QuizTakePage({
 
   const [timerRemaining, setTimerRemaining] = useState(0);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // One-shot guard so Z auto-grading fires once per finished attempt.
+  const zAutoGradedRef = useRef(false);
   const currentParam = searchParams.get("q");
 
   // Live score for header pill (mirrors public take page)
@@ -301,6 +303,7 @@ export default function QuizTakePage({
       setMaxStreak(0);
 
       setTimerRemaining(cfg.timerSeconds);
+      zAutoGradedRef.current = false;
       setScreen("quiz");
     },
     [quiz, currentParam],
@@ -314,6 +317,7 @@ export default function QuizTakePage({
     setZResults({});
     setStreak(0);
     setMaxStreak(0);
+    zAutoGradedRef.current = false;
     setScreen("config");
   }, [stopTimer]);
 
@@ -346,10 +350,23 @@ export default function QuizTakePage({
           action: { label: "Upgrade", onClick: () => router.push("/pricing") },
         });
       } else {
-        toast.error("Grading failed. Please try again.");
+        toast.error("Grading with Z failed.");
       }
     }
   }, [quiz, config, questions, answers, zResults, id, gradeQuiz, router]);
+
+  // When the quiz finishes, hand any answered free-text questions to Z for
+  // grading (if enabled) — one shot per attempt; results stream into zResults.
+  useEffect(() => {
+    if (screen !== "results" || !config || !config.useZGrading) return;
+    if (zAutoGradedRef.current || gradeQuiz.isPending) return;
+    const hasUngradedFreeText = questions.some(
+      (q) => isFreeResponseType(q.type) && answers[q.id] && !zResults[q.id],
+    );
+    if (!hasUngradedFreeText) return;
+    zAutoGradedRef.current = true;
+    handleGradeWithZ();
+  }, [screen, config, questions, answers, zResults, gradeQuiz.isPending, handleGradeWithZ]);
 
   if (isLoading) {
     return (
@@ -402,8 +419,6 @@ export default function QuizTakePage({
         zGradingResults={Object.values(zResults)}
         config={config}
         onReset={handleRetake}
-        onGradeWithZ={handleGradeWithZ}
-        isGradingZ={gradeQuiz.isPending}
         quizTitle={quiz.title}
       />
     );

--- a/src/app/app/quizzes/[id]/take/page.tsx
+++ b/src/app/app/quizzes/[id]/take/page.tsx
@@ -399,8 +399,11 @@ export default function QuizTakePage({
       <QuizReviewResults
         questions={questions}
         userAnswers={answers}
+        zGradingResults={Object.values(zResults)}
         config={config}
         onReset={handleRetake}
+        onGradeWithZ={handleGradeWithZ}
+        isGradingZ={gradeQuiz.isPending}
         quizTitle={quiz.title}
       />
     );

--- a/src/app/quizzes/[id]/take/page.tsx
+++ b/src/app/quizzes/[id]/take/page.tsx
@@ -536,6 +536,7 @@ export default function SystemQuizTakePage({
       <QuizReviewResults
         questions={questions}
         userAnswers={answers}
+        zGradingResults={Object.values(zResults)}
         config={
           config ?? {
             selectedKeys: [],
@@ -551,6 +552,8 @@ export default function SystemQuizTakePage({
           }
         }
         onReset={handleRetake}
+        onGradeWithZ={handleGradeWithZ}
+        isGradingZ={gradeQuiz.isPending}
         quizTitle={quiz.title}
       />
     );

--- a/src/app/quizzes/[id]/take/page.tsx
+++ b/src/app/quizzes/[id]/take/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useEffect, useState, useMemo, useCallback } from "react";
+import { use, useEffect, useState, useMemo, useCallback, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
@@ -258,6 +258,8 @@ export default function SystemQuizTakePage({
   );
   const [config, setConfig] = useState<QuizConfig | null>(null);
   const [viewQuiz, setViewQuiz] = useState<SystemQuizDetail | null>(null);
+  // One-shot guard so Z auto-grading fires once per finished attempt.
+  const zAutoGradedRef = useRef(false);
   const currentParam = searchParams.get("q");
   const isViewMode = searchParams.get("mode") === "view";
 
@@ -266,6 +268,7 @@ export default function SystemQuizTakePage({
       const fullQuiz = await startQuiz.mutateAsync(id);
       if (!fullQuiz) return;
       setConfig(newConfig);
+      zAutoGradedRef.current = false;
       const selectedQuestions = buildQuestions(fullQuiz, newConfig);
       setQuestions(selectedQuestions);
       setSelfMarks({});
@@ -416,6 +419,7 @@ export default function SystemQuizTakePage({
     setCurrent(0);
     setDone(false);
     setStarted(false);
+    zAutoGradedRef.current = false;
   };
 
   const handleGradeWithZ = useCallback(async () => {
@@ -449,10 +453,23 @@ export default function SystemQuizTakePage({
           action: { label: "Upgrade", onClick: () => router.push("/pricing") },
         });
       } else {
-        toast.error("Grading failed. Please try again.");
+        toast.error("Grading with Z failed.");
       }
     }
   }, [quiz, config, questions, answers, zResults, id, gradeQuiz, router]);
+
+  // When the quiz finishes, hand any answered free-text questions to Z for
+  // grading (if enabled) — one shot per attempt; results stream into zResults.
+  useEffect(() => {
+    if (!done || !config || !config.useZGrading || isViewMode) return;
+    if (zAutoGradedRef.current || gradeQuiz.isPending) return;
+    const hasUngradedFreeText = questions.some(
+      (q) => isFreeResponseType(q.type) && answers[q.id] && !zResults[q.id],
+    );
+    if (!hasUngradedFreeText) return;
+    zAutoGradedRef.current = true;
+    handleGradeWithZ();
+  }, [done, config, isViewMode, questions, answers, zResults, gradeQuiz.isPending, handleGradeWithZ]);
 
   const score = useMemo(() => {
     return questions.filter((q) => {
@@ -552,8 +569,6 @@ export default function SystemQuizTakePage({
           }
         }
         onReset={handleRetake}
-        onGradeWithZ={handleGradeWithZ}
-        isGradingZ={gradeQuiz.isPending}
         quizTitle={quiz.title}
       />
     );

--- a/src/components/app/quizzes/quiz-review-results.tsx
+++ b/src/components/app/quizzes/quiz-review-results.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { CheckCircle2, XCircle, RotateCcw, ArrowRight, Sparkles, Loader2 } from "lucide-react";
+import { CheckCircle2, XCircle, RotateCcw, ArrowRight } from "lucide-react";
 import { QuestionMarkdown, QuestionTypeBadge } from "@/components/app/quizzes/question-renderer";
 import { answersMatch } from "@/lib/quiz-answer";
 import type { QuizConfig, QuizQuestion, ZGradeResultItem } from "@/types/session";
@@ -121,8 +121,6 @@ export function QuizReviewResults({
   selfMarkings = {},
   config,
   onReset,
-  onGradeWithZ,
-  isGradingZ = false,
   quizTitle = "Quiz",
 }: {
   questions: QuizQuestion[];
@@ -131,24 +129,10 @@ export function QuizReviewResults({
   selfMarkings?: Record<string, boolean>;
   config: QuizConfig;
   onReset: () => void;
-  onGradeWithZ?: () => void;
-  isGradingZ?: boolean;
   quizTitle?: string;
 }) {
   let totalScore = 0;
   let correctCount = 0;
-
-  // Free-text answers the learner gave that Z hasn't graded yet — these gate
-  // the explicit "Grade with Z" call-to-action.
-  const ungradedFreeText = questions.filter(
-    (q) =>
-      isFreeResponseType(q.type) &&
-      (userAnswers[q.id] || "").trim() !== "" &&
-      !zGradingResults.some((z) => z.questionId === q.id),
-  );
-  const showGradeWithZ = Boolean(
-    config.useZGrading && onGradeWithZ && ungradedFreeText.length > 0,
-  );
 
   questions.forEach((q) => {
     const given = userAnswers[q.id] || "";
@@ -193,30 +177,6 @@ export function QuizReviewResults({
                 Pass mark · {config.passingScore || 70}%
               </span>
             </div>
-
-            {/* Explicit Z-grading call-to-action for free-text answers */}
-            {showGradeWithZ && (
-              <div className="pt-3">
-                <button
-                  type="button"
-                  onClick={onGradeWithZ}
-                  disabled={isGradingZ}
-                  className="inline-flex items-center gap-2 rounded-2xl bg-[#DFFF61] px-5 py-2.5 text-xs font-extrabold text-slate-950 transition hover:bg-lime-300 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {isGradingZ ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Sparkles className="h-4 w-4" />
-                  )}
-                  {isGradingZ
-                    ? "Grading…"
-                    : `Grade with Z (${ungradedFreeText.length})`}
-                </button>
-                <p className="mt-2 text-[10px] font-semibold text-slate-500">
-                  Z will mark your written answers and update your score.
-                </p>
-              </div>
-            )}
           </div>
 
           {/* Right Giant Score Circle */}

--- a/src/components/app/quizzes/quiz-review-results.tsx
+++ b/src/components/app/quizzes/quiz-review-results.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { motion } from "framer-motion";
-import { CheckCircle2, XCircle, RotateCcw, ArrowRight } from "lucide-react";
+import { CheckCircle2, XCircle, RotateCcw, ArrowRight, Sparkles, Loader2 } from "lucide-react";
 import { QuestionMarkdown, QuestionTypeBadge } from "@/components/app/quizzes/question-renderer";
 import { answersMatch } from "@/lib/quiz-answer";
 import type { QuizConfig, QuizQuestion, ZGradeResultItem } from "@/types/session";
@@ -121,6 +121,8 @@ export function QuizReviewResults({
   selfMarkings = {},
   config,
   onReset,
+  onGradeWithZ,
+  isGradingZ = false,
   quizTitle = "Quiz",
 }: {
   questions: QuizQuestion[];
@@ -129,10 +131,24 @@ export function QuizReviewResults({
   selfMarkings?: Record<string, boolean>;
   config: QuizConfig;
   onReset: () => void;
+  onGradeWithZ?: () => void;
+  isGradingZ?: boolean;
   quizTitle?: string;
 }) {
   let totalScore = 0;
   let correctCount = 0;
+
+  // Free-text answers the learner gave that Z hasn't graded yet — these gate
+  // the explicit "Grade with Z" call-to-action.
+  const ungradedFreeText = questions.filter(
+    (q) =>
+      isFreeResponseType(q.type) &&
+      (userAnswers[q.id] || "").trim() !== "" &&
+      !zGradingResults.some((z) => z.questionId === q.id),
+  );
+  const showGradeWithZ = Boolean(
+    config.useZGrading && onGradeWithZ && ungradedFreeText.length > 0,
+  );
 
   questions.forEach((q) => {
     const given = userAnswers[q.id] || "";
@@ -177,6 +193,30 @@ export function QuizReviewResults({
                 Pass mark · {config.passingScore || 70}%
               </span>
             </div>
+
+            {/* Explicit Z-grading call-to-action for free-text answers */}
+            {showGradeWithZ && (
+              <div className="pt-3">
+                <button
+                  type="button"
+                  onClick={onGradeWithZ}
+                  disabled={isGradingZ}
+                  className="inline-flex items-center gap-2 rounded-2xl bg-[#DFFF61] px-5 py-2.5 text-xs font-extrabold text-slate-950 transition hover:bg-lime-300 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isGradingZ ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Sparkles className="h-4 w-4" />
+                  )}
+                  {isGradingZ
+                    ? "Grading…"
+                    : `Grade with Z (${ungradedFreeText.length})`}
+                </button>
+                <p className="mt-2 text-[10px] font-semibold text-slate-500">
+                  Z will mark your written answers and update your score.
+                </p>
+              </div>
+            )}
           </div>
 
           {/* Right Giant Score Circle */}


### PR DESCRIPTION
This pull request adds an explicit "Grade with Z" button to the quiz review results, allowing users to trigger Z-based grading for ungraded free-text answers. The button is conditionally shown when there are written answers that haven't yet been graded by Z, and it displays a loading state during grading. The changes also update the relevant page components to pass the necessary props for this new feature.

**New Z-grading call-to-action in quiz review:**

* Added a "Grade with Z" button to `QuizReviewResults`, which appears when there are ungraded free-text answers and allows users to trigger Z-grading manually. The button shows a loading spinner while grading is in progress and updates the score once grading is complete. [[1]](diffhunk://#diff-5a3166edab8dbfc4b5381e8891280520c6f5e0b7d8dd3ce52504635af02aa622R134-R152) [[2]](diffhunk://#diff-5a3166edab8dbfc4b5381e8891280520c6f5e0b7d8dd3ce52504635af02aa622R196-R219)

**Prop and state handling:**

* Updated `QuizReviewResults` to accept new props: `onGradeWithZ`, `isGradingZ`, and `zGradingResults`, used to control the button's visibility, loading state, and display of Z-grading results. [[1]](diffhunk://#diff-5a3166edab8dbfc4b5381e8891280520c6f5e0b7d8dd3ce52504635af02aa622R124-R125) [[2]](diffhunk://#diff-5a3166edab8dbfc4b5381e8891280520c6f5e0b7d8dd3ce52504635af02aa622R134-R152)
* Updated `QuizTakePage` and `SystemQuizTakePage` to pass the new props (`onGradeWithZ`, `isGradingZ`, and `zGradingResults`) to `QuizReviewResults`. ([src/app/app/quizzes/[id]/take/page.tsxR402-R406](diffhunk://#diff-52be56219c9c53d1ce83961173cee988398cb75b8e449b058499ea82527f7568R402-R406), [src/app/quizzes/[id]/take/page.tsxR539](diffhunk://#diff-abb547ba99b190b56f62d10c49ccf37c00e97b40404d3b1b19ad6b0b26e0738fR539), [src/app/quizzes/[id]/take/page.tsxR555-R556](diffhunk://#diff-abb547ba99b190b56f62d10c49ccf37c00e97b40404d3b1b19ad6b0b26e0738fR555-R556))

**UI enhancements:**

* Added `Sparkles` and `Loader2` icons to visually indicate the Z-grading action and loading state.