### PR TITLE
[feat]: enhance document reader navigation and fix state handling

### DIFF
--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -56,6 +56,7 @@ export default function ChatPage() {
     truncateFrom,
     activeMaterialId,
     setActiveMaterialId,
+    openDocument,
   } = useAppLayout();
 
   // The default start page of any session is the journey page
@@ -227,20 +228,36 @@ export default function ChatPage() {
     }
   };
 
-  // Derive the most-recent unresolved directive messageId
+  // Derive the most-recent unresolved directive or interactive question artifact messageId
   const activeDirectiveMessageId = useMemo(() => {
     for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].type === "directive" && messages[i].directive) {
-        return messages[i].messageId;
+      const m = messages[i];
+      if (m.type === "directive" && m.directive) {
+        return m.messageId || m.id;
+      }
+      if (
+        m.artifact &&
+        ["question", "ask_question", "ask_questions", "quiz", "verification"].includes(
+          String(m.artifact.type || "").toLowerCase(),
+        )
+      ) {
+        return m.messageId || m.id;
       }
     }
     return null;
   }, [messages]);
 
+  const handleOpenSource = useCallback(
+    (materialId: string, pageNumber?: number) => {
+      openDocument(materialId, pageNumber);
+    },
+    [openDocument],
+  );
+
   const isOpenEndedQuestionActive = useMemo(() => {
     if (activeDirectiveMessageId) {
       const activeMsg = messages.find(
-        (m) => m.messageId === activeDirectiveMessageId
+        (m) => (m.messageId || m.id) === activeDirectiveMessageId,
       );
       if (activeMsg?.directive?.type === "ASK_QUESTION") {
         const payload = activeMsg.directive.payload as any;
@@ -248,7 +265,10 @@ export default function ChatPage() {
           return true;
         }
       }
-      if (activeMsg?.artifact?.type === "question") {
+      if (
+        activeMsg?.artifact?.type === "question" ||
+        activeMsg?.artifact?.type === "ask_question"
+      ) {
         const payload = (activeMsg.artifact.content || {}) as any;
         if (!payload?.options || payload.options.length === 0) {
           return true;
@@ -519,12 +539,6 @@ export default function ChatPage() {
     () => sendMessage("Pomodoro done, ready to continue", undefined, true),
     [sendMessage],
   );
-
-  // Open Document Reader Lightbox
-  const handleOpenSource = (materialId: string, pageNumber?: number) => {
-    setActiveMaterialId(materialId);
-    setReferencePage(pageNumber);
-  };
 
   // Guard: invalid session
   if (!sessionId || sessionId === "undefined") {

--- a/src/components/app/center/DocumentReader.tsx
+++ b/src/components/app/center/DocumentReader.tsx
@@ -108,12 +108,18 @@ export function DocumentReader({
     }
   }
 
-  const scrollToPage = (pageNum: number) => {
+  const scrollToPage = useCallback((pageNum: number) => {
     const target = pageRefs.current[pageNum - 1];
     if (target) {
       target.scrollIntoView({ behavior: "smooth", block: "start" });
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (referencePage && numPages && referencePage <= numPages) {
+      scrollToPage(referencePage);
+    }
+  }, [referencePage, numPages, scrollToPage]);
 
   const zoom = (delta: number) => {
     setScale((prev) => Math.min(Math.max(0.6, Number((prev + delta).toFixed(1))), 2.0));
@@ -211,7 +217,7 @@ export function DocumentReader({
         {/* Content Scrolling Canvas Area matching screenshot */}
         <div
           ref={scrollContainerRef}
-          className="flex-1 overflow-y-auto p-6 sm:p-8 flex flex-col items-center min-h-0 bg-[#F7F7F7] scroll-smooth"
+          className="flex-1 overflow-y-auto p-6 sm:p-8 flex flex-col items-center min-h-0 bg-[#F7F7F7] scroll-smooth scrollbar-none [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none]"
         >
           {objectUrl ? (
             <Document
@@ -229,7 +235,7 @@ export function DocumentReader({
               }
             >
               {pagesList.map((pageNum) => {
-                const isReference = referencePage ? pageNum === referencePage : pageNum === 17;
+                const isReference = Boolean(referencePage && pageNum === referencePage);
 
                 return (
                   <div key={pageNum} className="flex flex-col items-center w-full max-w-2xl mb-8">

--- a/src/components/app/center/MessageFeed.tsx
+++ b/src/components/app/center/MessageFeed.tsx
@@ -360,7 +360,10 @@ export function MessageFeed({
         }
 
         /* ── Z messages / narration / attached artifacts (NO BACKGROUND) ── */
-        const resolved = msg.messageId !== activeDirectiveMessageId;
+        const msgId = msg.messageId || msg.id;
+        const resolved = Boolean(
+          activeDirectiveMessageId && msgId !== activeDirectiveMessageId,
+        );
         return (
           <ZMessageCanvasNode
             key={msg.id || msg.messageId || index}

--- a/src/components/app/layout/app-session-layout.tsx
+++ b/src/components/app/layout/app-session-layout.tsx
@@ -57,6 +57,9 @@ export interface AppLayoutContextValue {
   messageMutation: ReturnType<typeof useAppMessage>;
   activeMaterialId: string | null;
   setActiveMaterialId: (id: string | null) => void;
+  referencePage?: number;
+  setReferencePage: (page: number | undefined) => void;
+  openDocument: (materialId: string, pageNumber?: number) => void;
   truncateAfter: (messageId: string) => void;
   truncateFrom: (messageId: string) => void;
 }
@@ -267,6 +270,13 @@ export function AppSessionLayout({ children, sessionId }: AppSessionLayoutProps)
     [createNoteMutation],
   );
 
+  const [referencePage, setReferencePage] = useState<number | undefined>(undefined);
+
+  const openDocument = useCallback((materialId: string, pageNumber?: number) => {
+    setActiveMaterialId(materialId);
+    setReferencePage(pageNumber);
+  }, []);
+
   // Context value (no sidebars)
   const contextValue: AppLayoutContextValue = {
     sessionId,
@@ -282,6 +292,9 @@ export function AppSessionLayout({ children, sessionId }: AppSessionLayoutProps)
     messageMutation: messageAction,
     activeMaterialId,
     setActiveMaterialId,
+    referencePage,
+    setReferencePage,
+    openDocument,
     truncateAfter: stream.truncateAfter,
     truncateFrom: stream.truncateFrom,
   };
@@ -334,7 +347,11 @@ export function AppSessionLayout({ children, sessionId }: AppSessionLayoutProps)
                 <DocumentReader
                   materialId={activeMaterialId}
                   sessionId={sessionId}
-                  onClose={() => setActiveMaterialId(null)}
+                  referencePage={referencePage}
+                  onClose={() => {
+                    setActiveMaterialId(null);
+                    setReferencePage(undefined);
+                  }}
                 />
               )}
             </AnimatePresence>

--- a/src/components/app/session/ArtifactCard.tsx
+++ b/src/components/app/session/ArtifactCard.tsx
@@ -283,11 +283,12 @@ function AskQuestionCard({
   const explanation = payload.explanation || "";
   const hint = payload.hint || "";
 
+  // Check user-submitted responses only — payload.answer is the model's solution key
   const persistedAnswer =
-    payload.selectedOption ||
+    payload.userAnswer ||
     payload.submittedAnswer ||
-    payload.userAnswers?.[0] ||
-    payload.answer ||
+    payload.selectedOption ||
+    (Array.isArray(payload.userAnswers) && payload.userAnswers[0]) ||
     "";
 
   const [textAnswer, setTextAnswer] = useState(persistedAnswer);
@@ -307,7 +308,12 @@ function AskQuestionCard({
     }
   };
 
-  if (resolved || Boolean(persistedAnswer)) {
+  const isResolved =
+    Boolean(submittedAnswerRef.current) ||
+    Boolean(persistedAnswer) ||
+    (resolved && Boolean(persistedAnswer));
+
+  if (isResolved) {
     return (
       <QAResolvedCard
         entries={[
@@ -1600,7 +1606,7 @@ function ShowExpositionCard({
   onContinue = () => {},
 }: ShowExpositionCardProps) {
   // Extract text content from various backend formats
-  const markdownText =
+  const rawMarkdown =
     payload.markdown ||
     payload.body ||
     payload.content ||
@@ -1612,11 +1618,29 @@ function ShowExpositionCard({
     "";
 
   const title = payload.topicTitle || payload.title || "Concept Exposition";
-  const citations = Array.isArray(payload.citations)
+  const initialCitations = Array.isArray(payload.citations)
     ? payload.citations
     : payload.citation
     ? [payload.citation]
     : [];
+
+  const SOURCE_REGEX = /\s*\((?:Source|Ref):\s*([^,)]+)(?:,\s*Chapter\s*[^,)]+)?(?:,\s*p(?:p)?\.?\s*(\d+))?.*?\)\s*$/im;
+
+  let parsedCitations = [...initialCitations];
+  let markdownText = rawMarkdown;
+
+  const match = rawMarkdown.match(SOURCE_REGEX);
+  if (match) {
+    markdownText = rawMarkdown.replace(SOURCE_REGEX, "").trim();
+    if (parsedCitations.length === 0) {
+      const docName = match[1]?.trim() || "Source Document";
+      const pageNum = match[2] ? parseInt(match[2], 10) : undefined;
+      parsedCitations.push({
+        filename: docName,
+        pageNumber: pageNum,
+      });
+    }
+  }
 
   return (
     <CardWrapper
@@ -1637,9 +1661,9 @@ function ShowExpositionCard({
         </div>
 
         {/* Citations list */}
-        {citations.length > 0 && (
+        {parsedCitations.length > 0 && (
           <div className="pt-2 flex flex-wrap gap-2 border-t border-slate-100">
-            {citations.map((c: any, i: number) => {
+            {parsedCitations.map((c: any, i: number) => {
               const filename = c.filename || "Study Material";
               const pageNumber = c.pageNumber || c.page;
               return (


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to document reference handling, message resolution logic, and citation parsing in the chat and document reader components. The changes aim to make document opening and referencing more robust and to improve the user experience when interacting with citations and question artifacts.

**Document Reference and Opening Improvements:**

* Introduced a unified `openDocument` method in the app layout context, which sets both the active material and the reference page, allowing consistent document opening from anywhere in the app (`app-session-layout.tsx`, `page.tsx`). [[1]](diffhunk://#diff-32667235572e11ef6188cf6e2a3af875c287722c6018c464e636cd6a969d0a71R60-R62) [[2]](diffhunk://#diff-32667235572e11ef6188cf6e2a3af875c287722c6018c464e636cd6a969d0a71R273-R279) [[3]](diffhunk://#diff-32667235572e11ef6188cf6e2a3af875c287722c6018c464e636cd6a969d0a71R295-R297) [src/app/app/[id]/page.tsxR59](diffhunk://#diff-d84e312912b46897f32c24697740b97d56f2e00ce410aae583d49bfc208dc0f4R59), [src/app/app/[id]/page.tsxL523-L528](diffhunk://#diff-d84e312912b46897f32c24697740b97d56f2e00ce410aae583d49bfc208dc0f4L523-L528))
* Updated the `DocumentReader` to automatically scroll to the referenced page when opened, using a `useEffect` and `useCallback` for smooth scrolling. Also improved scrollbar hiding for a cleaner UI (`DocumentReader.tsx`). [[1]](diffhunk://#diff-6ae367955075ab02a2e885dc22b4921c1e78a530593625dfc5de6c1ac1b0c904L111-R122) [[2]](diffhunk://#diff-6ae367955075ab02a2e885dc22b4921c1e78a530593625dfc5de6c1ac1b0c904L214-R220)

**Message and Artifact Handling:**

* Enhanced the logic for identifying the most recent unresolved directive or interactive question artifact, ensuring accurate tracking of active questions in the chat (`page.tsx`, `MessageFeed.tsx`). ([src/app/app/[id]/page.tsxL230-R271](diffhunk://#diff-d84e312912b46897f32c24697740b97d56f2e00ce410aae583d49bfc208dc0f4L230-R271), [src/components/app/center/MessageFeed.tsxL363-R366](diffhunk://#diff-e676a852e9523c6d5a8b10b7ea663fc5934ef17b9b2827a1e6bb6762c285a37eL363-R366))
* Improved resolution logic for question artifacts to more reliably determine when a question has been answered or resolved, avoiding false positives (`ArtifactCard.tsx`). [[1]](diffhunk://#diff-03f4d0612bae4fafbcd164135c48d8f4f87b42c4c012491d3e15701e6e748189R286-R291) [[2]](diffhunk://#diff-03f4d0612bae4fafbcd164135c48d8f4f87b42c4c012491d3e15701e6e748189L310-R316)

**Citation Extraction and Display:**

* Added logic to extract citations from the end of markdown exposition content using a regex, allowing for automatic citation parsing even when not explicitly provided by the backend. Parsed citations are now displayed consistently in exposition cards (`ArtifactCard.tsx`). [[1]](diffhunk://#diff-03f4d0612bae4fafbcd164135c48d8f4f87b42c4c012491d3e15701e6e748189L1603-R1609) [[2]](diffhunk://#diff-03f4d0612bae4fafbcd164135c48d8f4f87b42c4c012491d3e15701e6e748189L1615-R1644) [[3]](diffhunk://#diff-03f4d0612bae4fafbcd164135c48d8f4f87b42c4c012491d3e15701e6e748189L1640-R1666)

**Other UI/UX Improvements:**

* Fixed logic for highlighting reference pages and improved conditional checks for reference highlighting in the document reader (`DocumentReader.tsx`).
* Ensured that closing the document reader resets both the active material and the reference page for proper cleanup (`app-session-layout.tsx`).